### PR TITLE
feat(mtagro): remove `vesin`

### DIFF
--- a/cmake/gmxManageMetatomic.cmake
+++ b/cmake/gmxManageMetatomic.cmake
@@ -111,9 +111,6 @@ if(NOT GMX_METATOMIC STREQUAL "OFF")
     set(METATOMIC_TORCH_VERSION "0.1.7")
     set(METATOMIC_TORCH_SHA256 "726f5711b70c4b8cc80d9bc6c3ce6f3449f31d20acc644ab68dab083aa4ea572")
 
-    set(VESIN_VERSION "0.4.1")
-    set(VESIN_GIT_TAG "87dcad999fec47b29ab21be9662ef283edc7530b")
-
     set(DOWNLOAD_METATENSOR_DEFAULT ON)
     find_package(metatensor_torch ${METATENSOR_TORCH_VERSION} QUIET)
     if (metatensor_torch_FOUND)
@@ -168,23 +165,7 @@ if(NOT GMX_METATOMIC STREQUAL "OFF")
         find_package(metatomic_torch REQUIRED ${METATOMIC_TORCH_VERSION})
     endif()
 
-    # always fetch vesin
-    FetchContent_Declare(
-        vesin
-        GIT_REPOSITORY https://github.com/Luthaf/vesin.git
-        GIT_TAG ${VESIN_GIT_TAG}
-    )
-
-    FetchContent_MakeAvailable(vesin)
-    install(TARGETS vesin EXPORT libgromacs
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-
     list(APPEND GMX_COMMON_LIBRARIES
-        vesin
         metatensor
         metatomic_torch
         metatensor_torch

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -124,6 +124,7 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<cons
         int32_t atom_i = pairlist[2 * i];
         int32_t atom_j = pairlist[2 * i + 1];
 
+        // Access IVec elements (integers)
         pair_samples_ptr[i][0] = static_cast<int32_t>(atom_i);
         pair_samples_ptr[i][1] = static_cast<int32_t>(atom_j);
         pair_samples_ptr[i][2] = cellShifts[i][0];
@@ -131,19 +132,25 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<cons
         pair_samples_ptr[i][4] = cellShifts[i][2];
 
         // Calculate r_ij = r_j - r_i + shift
-        double r_ij_x = positions[atom_j][0] - positions[atom_i][0] + shiftVectors[i][0];
-        double r_ij_y = positions[atom_j][1] - positions[atom_i][1] + shiftVectors[i][1];
-        double r_ij_z = positions[atom_j][2] - positions[atom_i][2] + shiftVectors[i][2];
+        double r_ij_x =
+                static_cast<double>(positions[atom_j][0] - positions[atom_i][0] + shiftVectors[i][0]);
+        double r_ij_y =
+                static_cast<double>(positions[atom_j][1] - positions[atom_i][1] + shiftVectors[i][1]);
+        double r_ij_z =
+                static_cast<double>(positions[atom_j][2] - positions[atom_i][2] + shiftVectors[i][2]);
 
         vectors_accessor[i][0][0] = r_ij_x;
         vectors_accessor[i][1][0] = r_ij_y;
         vectors_accessor[i][2][0] = r_ij_z;
     }
 
+    auto final_samples_values = pair_samples_values.to(device);
+    auto final_vectors        = vectors_cpu.to(dtype).to(device);
+
     auto neighbor_samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
             std::vector<std::string>{
                     "first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c" },
-            pair_samples_values.to(device));
+            final_samples_values);
 
     auto neighbor_component = torch::make_intrusive<metatensor_torch::LabelsHolder>(
             std::vector<std::string>{ "xyz" },
@@ -155,7 +162,7 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<cons
             torch::zeros({ 1, 1 }, torch::TensorOptions().dtype(torch::kInt32).device(device)));
 
     return torch::make_intrusive<metatensor_torch::TensorBlockHolder>(
-            vectors_cpu.to(dtype).to(device),
+            final_vectors,
             neighbor_samples,
             std::vector<metatensor_torch::Labels>{ neighbor_component },
             neighbor_properties);
@@ -442,7 +449,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
     // Force tensor - main rank fills, others have zeros
     torch::Tensor forceTensor =
-            torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64)).device(data_->device);
+            torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64).device(data_->device));
 
     // Virial tensor for pressure/stress calculations
     torch::Tensor virialTensor = torch::zeros({ 3, 3 }, torch::TensorOptions().dtype(torch::kFloat64));

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -59,7 +59,7 @@
 #include "gromacs/utility/stringutil.h"
 
 #ifdef DIM
-#    undef DIM
+#undef DIM
 #endif
 
 #include <metatensor/torch.hpp>
@@ -471,6 +471,9 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
     torch::Tensor forceTensor =
             torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
 
+    // Virial tensor for pressure/stress calculations
+    torch::Tensor virialTensor = torch::zeros({ 3, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
+
     if (mpiComm_.isMainRank())
     {
         auto gromacs_scalar_type = torch::kFloat32;
@@ -488,12 +491,19 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         auto torch_cell =
                 torch::from_blob(&box_, { 3, 3 }, blob_options).to(data_->dtype).to(data_->device);
 
+        // Create strain tensor for virial computation (like LAMMPS does)
+        auto strain = torch::eye(
+                3, torch::TensorOptions().dtype(data_->dtype).device(data_->device).requires_grad(true));
+
+        // Apply strain to cell: strained_cell = cell @ strain
+        auto strained_cell = torch::matmul(torch_cell, strain);
+
         auto torch_pbc = preparePbcType(options_.params_.pbcType_.get(), data_->device);
         auto torch_types =
                 torch::tensor(atomNumbers_, torch::TensorOptions().dtype(torch::kInt32)).to(data_->device);
 
         auto system = torch::make_intrusive<metatomic_torch::SystemHolder>(
-                torch_types, torch_positions, torch_cell, torch_pbc);
+                torch_types, torch_positions, strained_cell, torch_pbc);
 
         // Build neighbor list from GROMACS pairlist
         for (const auto& request : data_->nl_requests)
@@ -526,18 +536,28 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         outputs->enerd_.term[InteractionFunction::MetatomicPotentialEnergy] =
                 static_cast<real>(energy_tensor.item<double>());
 
-        energy_tensor.backward();
-        auto grad   = system->positions().grad();
-        forceTensor = -grad.to(torch::kCPU).to(torch::kFloat64);
+        // Reset gradients before backward
+        torch_positions.mutable_grad() = torch::Tensor();
+        strain.mutable_grad()          = torch::Tensor();
+
+        // Compute forces and virial via backward propagation
+        energy_tensor.backward(-torch::ones_like(energy_tensor));
+
+        auto grad   = torch_positions.grad();
+        forceTensor = grad.to(torch::kCPU).to(torch::kFloat64);
+
+        // Get virial from strain gradient
+        virialTensor = strain.grad().to(torch::kCPU).to(torch::kFloat64);
     }
 
     // Distribute forces (sumReduce acts as broadcast since non-main ranks have zeros)
     if (mpiComm_.isParallel())
     {
         mpiComm_.sumReduce(n_atoms * 3, static_cast<double*>(forceTensor.data_ptr()));
+        mpiComm_.sumReduce(9, static_cast<double*>(virialTensor.data_ptr()));
     }
 
-    // Apply to local atoms only
+    // Apply forces to local atoms only
     auto forceAccessor = forceTensor.accessor<double, 2>();
     for (int i = 0; i < n_atoms; ++i)
     {
@@ -546,6 +566,17 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
             outputs->forceWithVirial_.force_[inputToLocalIndex_[i]][0] += forceAccessor[i][0];
             outputs->forceWithVirial_.force_[inputToLocalIndex_[i]][1] += forceAccessor[i][1];
             outputs->forceWithVirial_.force_[inputToLocalIndex_[i]][2] += forceAccessor[i][2];
+        }
+    }
+
+    // Apply virial contribution
+    // GROMACS uses a 3x3 virial tensor in forceWithVirial_
+    auto virialAccessor = virialTensor.accessor<double, 2>();
+    for (int i = 0; i < 3; ++i)
+    {
+        for (int j = 0; j < 3; ++j)
+        {
+            outputs->forceWithVirial_.virial_[i][j] += virialAccessor[i][j];
         }
     }
 }

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -83,38 +83,40 @@ static std::optional<ptrdiff_t> indexOf(ArrayRef<const int32_t> vec, const int32
 
 static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
 {
-    torch::Tensor pbcTensor =
-            torch::tensor({ true, true, true }, torch::TensorOptions().dtype(torch::kBool)).device(device);
+    auto options = torch::TensorOptions().dtype(torch::kBool).device(device);
+
     if (*pbcType == PbcType::XY)
     {
-        pbcTensor[2] = false;
+        return torch::tensor({ true, true, false }, options);
+    }
+    else if (*pbcType == PbcType::No)
+    {
+        return torch::tensor({ false, false, false }, options);
     }
     else if (*pbcType != PbcType::Xyz)
     {
         GMX_THROW(InconsistentInputError("PBC type not supported."));
     }
-    return pbcTensor.to(device);
+    return torch::tensor({ true, true, true }, options);
 }
 
 static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<const int32_t> pairlist,
                                                                    ArrayRef<const RVec> shiftVectors,
-                                                                   ArrayRef<const RVec> cellShifts,
+                                                                   ArrayRef<const IVec> cellShifts,
                                                                    ArrayRef<const RVec> positions,
                                                                    torch::Device        device,
                                                                    torch::ScalarType    dtype)
 {
     const int64_t n_pairs = static_cast<int64_t>(pairlist.size() / 2);
 
-    auto pair_samples_values =
-            torch::zeros({ n_pairs, 5 }, torch::TensorOptions().dtype(torch::kInt32)).device(device);
-    auto pair_samples_ptr = pair_samples_values.accessor<int32_t, 2>();
+    auto cpu_int_options   = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
+    auto cpu_float_options = torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU);
 
-    // Full interatomic vectors (rj - ri + shift), not just shifts.
-    auto pair_vectors =
-            torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64)).device(device);
+    auto pair_samples_values = torch::zeros({ n_pairs, 5 }, cpu_int_options);
+    auto pair_samples_ptr    = pair_samples_values.accessor<int32_t, 2>();
 
-    auto vectors_cpu =
-            torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64)).device(device);
+    // Full interatomic vectors (rj - ri + shift)
+    auto vectors_cpu      = torch::zeros({ n_pairs, 3, 1 }, cpu_float_options);
     auto vectors_accessor = vectors_cpu.accessor<double, 3>();
 
     for (int64_t i = 0; i < n_pairs; i++)

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -73,7 +73,7 @@
 namespace gmx
 {
 
-static std::optional<ptrdiff_t> indexOf(ArrayRef<const int> vec, const int val)
+static std::optional<ptrdiff_t> indexOf(ArrayRef<const int32_t> vec, const int32_t val)
 {
     auto it = std::find(vec.begin(), vec.end(), val);
     if (it == vec.end())
@@ -83,11 +83,11 @@ static std::optional<ptrdiff_t> indexOf(ArrayRef<const int> vec, const int val)
     return std::distance(vec.begin(), it);
 }
 
-static std::tuple<std::string, std::optional<int>> getMdrunActiveDevice()
+static std::tuple<std::string, std::optional<int32_t>> getMdrunActiveDevice()
 {
 #if GMX_GPU_CUDA || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_CUDA_TARGET)
     GMX_RELEASE_ASSERT(torch::hasCUDA(), "Libtorch not compiled with CUDA support.");
-    int activeDevice;
+    int32_t activeDevice;
     if (cudaGetDevice(&activeDevice) != cudaSuccess)
     {
         GMX_THROW(InternalError("cudaGetDevice failed."));
@@ -97,7 +97,7 @@ static std::tuple<std::string, std::optional<int>> getMdrunActiveDevice()
 #    ifndef USE_ROCM
     GMX_THROW(InternalError("Libtorch not compiled with HIP support."));
 #    endif
-    int activeDevice;
+    int32_t activeDevice;
     if (hipGetDevice(&activeDevice) != hipSuccess)
     {
         GMX_THROW(InternalError("hipGetDevice failed."));
@@ -173,7 +173,7 @@ static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
     return pbcTensor.to(device);
 }
 
-static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<const int> pairlist,
+static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<const int32_t> pairlist,
                                                                    ArrayRef<const RVec> shiftVectors,
                                                                    ArrayRef<const RVec> positions,
                                                                    torch::Device        device,
@@ -192,8 +192,8 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<cons
 
     for (int64_t i = 0; i < n_pairs; i++)
     {
-        int atom_i = pairlist[2 * i];
-        int atom_j = pairlist[2 * i + 1];
+        int32_t atom_i = pairlist[2 * i];
+        int32_t atom_j = pairlist[2 * i + 1];
 
         pair_samples_ptr[i][0] = static_cast<int32_t>(atom_i);
         pair_samples_ptr[i][1] = static_cast<int32_t>(atom_j);
@@ -329,7 +329,7 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
     }
 
     const auto& mtaIndices = options_.params_.mtaIndices_;
-    const int   n_atoms    = static_cast<int>(mtaIndices.size());
+    const int32_t   n_atoms    = static_cast<int32_t>(mtaIndices.size());
 
     positions_.resize(n_atoms);
     atomNumbers_.resize(n_atoms, 0);
@@ -346,7 +346,7 @@ MetatomicForceProvider::~MetatomicForceProvider() = default;
 void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedistributedSignal& signal)
 {
     const auto& mtaIndices = options_.params_.mtaIndices_;
-    const int   numInput   = static_cast<int>(mtaIndices.size());
+    const int32_t   numInput   = static_cast<int32_t>(mtaIndices.size());
 
     inputToLocalIndex_.assign(numInput, -1);
     inputToGlobalIndex_.assign(numInput, -1);
@@ -357,12 +357,12 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
         GMX_RELEASE_ASSERT(signal.globalAtomIndices_.has_value(),
                            "Global atom indices required for DD.");
         auto      globalAtomIndices = signal.globalAtomIndices_.value();
-        const int numLocal          = signal.x_.size();
+        const int32_t numLocal          = signal.x_.size();
 
-        for (int i = 0; i < static_cast<int>(globalAtomIndices.size()); i++)
+        for (int32_t i = 0; i < static_cast<int32_t>(globalAtomIndices.size()); i++)
         {
-            int globalIdx = globalAtomIndices[i];
-            for (int j = 0; j < numInput; j++)
+            int32_t globalIdx = globalAtomIndices[i];
+            for (int32_t j = 0; j < numInput; j++)
             {
                 if (options_.params_.mtaAtoms_->globalIndex()[j] == globalIdx)
                 {
@@ -381,10 +381,10 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
     else
     {
         const auto* mtaAtoms = options_.params_.mtaAtoms_.get();
-        for (int i = 0; i < numInput; i++)
+        for (int32_t i = 0; i < numInput; i++)
         {
-            int localIndex         = mtaAtoms->localIndex()[i];
-            int globalIdx          = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
+            int32_t localIndex         = mtaAtoms->localIndex()[i];
+            int32_t globalIdx          = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
             inputToLocalIndex_[i]  = localIndex;
             inputToGlobalIndex_[i] = globalIdx;
             atomNumbers_[i]        = options_.params_.atoms_.atom[globalIdx].atomnumber;
@@ -429,13 +429,13 @@ void MetatomicForceProvider::preparePairlistInput()
 
     GMX_ASSERT(!fullPairlist_.empty(), "Pairlist empty!");
 
-    const int numPairs = gmx::ssize(fullPairlist_);
+    const int32_t numPairs = gmx::ssize(fullPairlist_);
     pairlistForModel_.clear();
     pairlistForModel_.reserve(2 * numPairs);
     shiftVectors_.clear();
     shiftVectors_.reserve(numPairs);
 
-    for (int i = 0; i < numPairs; i++)
+    for (int32_t i = 0; i < numPairs; i++)
     {
         const auto [atomPair, shiftIndex] = fullPairlist_[i];
 
@@ -448,8 +448,8 @@ void MetatomicForceProvider::preparePairlistInput()
             const IVec unitShift = shiftIndexToXYZ(shiftIndex);
             mvmul_ur0(box_, unitShift.toRVec(), shift);
 
-            pairlistForModel_.push_back(static_cast<int>(inputIdxA.value()));
-            pairlistForModel_.push_back(static_cast<int>(inputIdxB.value()));
+            pairlistForModel_.push_back(static_cast<int32_t>(inputIdxA.value()));
+            pairlistForModel_.push_back(static_cast<int32_t>(inputIdxB.value()));
             shiftVectors_.push_back(shift);
         }
     }
@@ -461,7 +461,7 @@ void MetatomicForceProvider::preparePairlistInput()
 
 void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, ForceProviderOutput* outputs)
 {
-    const int n_atoms = static_cast<int>(options_.params_.mtaIndices_.size());
+    const int32_t n_atoms = static_cast<int32_t>(options_.params_.mtaIndices_.size());
 
     gatherAtomPositions(inputs.x_);
     copy_mat(inputs.box_, box_);
@@ -561,7 +561,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
     // Apply forces to local atoms only
     auto forceAccessor = forceTensor.accessor<double, 2>();
-    for (int i = 0; i < n_atoms; ++i)
+    for (int32_t i = 0; i < n_atoms; ++i)
     {
         if (inputToLocalIndex_[i] != -1)
         {
@@ -577,9 +577,9 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
     matrix virialMatrix;
     auto   virialAccessor = virialTensor.accessor<double, 2>();
     // TODO: technically this is DIM, not 3...
-    for (int i = 0; i < 3; ++i)
+    for (int32_t i = 0; i < 3; ++i)
     {
-        for (int j = 0; j < 3; ++j)
+        for (int32_t j = 0; j < 3; ++j)
         {
             virialMatrix[i][j] = virialAccessor[i][j];
         }

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -283,6 +283,22 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
 
 MetatomicForceProvider::~MetatomicForceProvider() = default;
 
+/*! \brief Updates the mapping between GROMACS local/global atom indices and the Metatomic model's input atoms.
+ *
+ * This function is subscribed to the `MDModulesAtomsRedistributedSignal`. It is called whenever
+ * atoms are redistributed across MPI ranks (Domain Decomposition) or reordered in memory (sorting).
+ *
+ * Its primary responsibilities are:
+ * 1. **Locate Input Atoms**: It iterates through the local atoms on the current rank to find
+ * which atoms correspond to the "input atoms" defined for the Metatomic model (via `mtaIndices`).
+ * 2. **Update Maps**: It populates `inputToLocalIndex_` (mapping model input index -> GROMACS local index)
+ * and `inputToGlobalIndex_` (mapping model input index -> GROMACS global tag).
+ * 3. **Gather Atomic Numbers**: It ensures `atomNumbers_` (Z numbers) are correctly associated with
+ * the current local atoms, performing an MPI reduction if necessary to gather data from
+ * distributed ranks.
+ *
+ * \param[in] signal Contains the new mapping of global atom indices to local buffer indices after redistribution.
+ */
 void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedistributedSignal& signal)
 {
     const auto&   mtaIndices = options_.params_.mtaIndices_;
@@ -335,6 +351,18 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
                        "Some atom numbers not set.");
 }
 
+/*! \brief Updates the internal position buffer with the coordinates of the Metatomic atoms.
+ *
+ * This function extracts the coordinates of the atoms relevant to the Metatomic model
+ * from the full GROMACS local atom array (`pos`).
+ *
+ * 1. **Filtering:** `pos` contains all local atoms (solute, solvent, ions).
+ * This function copies only the atoms defined in `mtaIndices` to `positions_`.
+ * 2. **Ordering/Packing:** GROMACS reorders atoms dynamically for Domain Decomposition.
+ * This function uses `inputToLocalIndex_` to collect atoms and pack them into a contiguous, ordered buffer
+ *
+ * \param[in] pos The array of all local atom coordinates for the current step.
+ */
 void MetatomicForceProvider::gatherAtomPositions(ArrayRef<const RVec> pos)
 {
     const size_t numInput = inputToLocalIndex_.size();

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -34,7 +34,7 @@
 /*! \internal \file
  * \brief
  * Implements the Metatomic Force Provider class with proper domain decomposition support.
- * 
+ *
  * \author Metatensor developers <https://github.com/metatensor>
  * \ingroup module_applied_forces
  */
@@ -43,6 +43,7 @@
 #include "metatomic_forceprovider.h"
 
 #include <cstdint>
+
 #include <unordered_map>
 
 #include "gromacs/domdec/localatomset.h"
@@ -122,25 +123,26 @@ static torch::Device determineDevice(const MDLogger& logger, const MpiComm& mpiC
         {
             if (!torch::cuda::is_available())
             {
-                GMX_THROW(InternalError(formatString(
-                        "GMX_METATOMIC_DEVICE='%s' but no device available.", env)));
+                GMX_THROW(InternalError(
+                        formatString("GMX_METATOMIC_DEVICE='%s' but no device available.", env)));
             }
             GMX_RELEASE_ASSERT(activeDevice.has_value(), "Could not determine active device.");
             device = torch::Device(torch::kCUDA, activeDevice.value());
         }
         else if (devLC != "cpu")
         {
-            GMX_THROW(InvalidInputError(formatString(
-                    "GMX_METATOMIC_DEVICE invalid value: '%s'.", env)));
+            GMX_THROW(InvalidInputError(formatString("GMX_METATOMIC_DEVICE invalid value: '%s'.", env)));
         }
-        GMX_LOG(logger.info).asParagraph()
+        GMX_LOG(logger.info)
+                .asParagraph()
                 .appendTextFormatted("Using device from GMX_METATOMIC_DEVICE: '%s'.", env);
     }
     else
     {
         if (torch::cuda::is_available() && activeDevice.has_value())
         {
-            GMX_LOG(logger.info).asParagraph()
+            GMX_LOG(logger.info)
+                    .asParagraph()
                     .appendText("Using " + toUpperCase(torchDeviceType) + " for Metatomic.");
             device = torch::Device(torch::kCUDA, activeDevice.value());
         }
@@ -167,31 +169,42 @@ static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
     return pbcTensor.to(device);
 }
 
-static metatensor_torch::TensorBlock buildNeighborListFromPairlist(
-        ArrayRef<const int>  pairlist,
-        ArrayRef<const RVec> shiftVectors,
-        torch::Device        device,
-        torch::ScalarType    dtype)
+static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<const int> pairlist,
+                                                                   ArrayRef<const RVec> shiftVectors,
+                                                                   ArrayRef<const RVec> positions,
+                                                                   torch::Device        device,
+                                                                   torch::ScalarType    dtype)
 {
     const int64_t n_pairs = static_cast<int64_t>(pairlist.size() / 2);
 
     auto pair_samples_values = torch::zeros({ n_pairs, 5 }, torch::TensorOptions().dtype(torch::kInt32));
     auto pair_samples_ptr = pair_samples_values.accessor<int32_t, 2>();
 
+    // Full interatomic vectors (rj - ri + shift), not just shifts.
     auto pair_vectors = torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64));
-    auto vectors_accessor = pair_vectors.accessor<double, 3>();
+
+    auto vectors_cpu = torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64));
+    auto vectors_accessor = vectors_cpu.accessor<double, 3>();
 
     for (int64_t i = 0; i < n_pairs; i++)
     {
-        pair_samples_ptr[i][0] = static_cast<int32_t>(pairlist[2 * i]);
-        pair_samples_ptr[i][1] = static_cast<int32_t>(pairlist[2 * i + 1]);
+        int atom_i = pairlist[2 * i];
+        int atom_j = pairlist[2 * i + 1];
+
+        pair_samples_ptr[i][0] = static_cast<int32_t>(atom_i);
+        pair_samples_ptr[i][1] = static_cast<int32_t>(atom_j);
         pair_samples_ptr[i][2] = 0;
         pair_samples_ptr[i][3] = 0;
         pair_samples_ptr[i][4] = 0;
 
-        vectors_accessor[i][0][0] = static_cast<double>(shiftVectors[i][0]);
-        vectors_accessor[i][1][0] = static_cast<double>(shiftVectors[i][1]);
-        vectors_accessor[i][2][0] = static_cast<double>(shiftVectors[i][2]);
+        // Calculate r_ij = r_j - r_i + shift
+        double r_ij_x = positions[atom_j][0] - positions[atom_i][0] + shiftVectors[i][0];
+        double r_ij_y = positions[atom_j][1] - positions[atom_i][1] + shiftVectors[i][1];
+        double r_ij_z = positions[atom_j][2] - positions[atom_i][2] + shiftVectors[i][2];
+
+        vectors_accessor[i][0][0] = r_ij_x;
+        vectors_accessor[i][1][0] = r_ij_y;
+        vectors_accessor[i][2][0] = r_ij_z;
     }
 
     auto neighbor_samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
@@ -209,7 +222,7 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(
             torch::zeros({ 1, 1 }, torch::TensorOptions().dtype(torch::kInt32).device(device)));
 
     return torch::make_intrusive<metatensor_torch::TensorBlockHolder>(
-            pair_vectors.to(dtype).to(device),
+            vectors_cpu.to(dtype).to(device),
             neighbor_samples,
             std::vector<metatensor_torch::Labels>{ neighbor_component },
             neighbor_properties);
@@ -222,9 +235,9 @@ struct MetatomicData
     metatomic_torch::ModelCapabilities capabilities;
     std::vector<metatomic_torch::NeighborListOptions> nl_requests;
     metatomic_torch::ModelEvaluationOptions           evaluations_options;
-    torch::ScalarType                                 dtype  = torch::kFloat32;
+    torch::ScalarType                                 dtype             = torch::kFloat32;
     bool                                              check_consistency = true;
-    torch::Device                                     device = torch::kCPU;
+    torch::Device                                     device            = torch::kCPU;
 };
 
 MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
@@ -303,7 +316,7 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
             GMX_THROW(APIError("Metatomic model must provide 'energy' output."));
         }
 
-        auto requested_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+        auto requested_output      = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
         requested_output->per_atom = false;
         requested_output->explicit_gradients = {};
 
@@ -319,7 +332,9 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
     inputToLocalIndex_.resize(n_atoms, -1);
     inputToGlobalIndex_.resize(n_atoms, -1);
 
-    GMX_LOG(logger_.info).asParagraph().appendText("MetatomicForceProvider initialization complete.");
+    GMX_LOG(logger_.info)
+            .asParagraph()
+            .appendText("MetatomicForceProvider initialization complete.");
 }
 
 MetatomicForceProvider::~MetatomicForceProvider() = default;
@@ -337,8 +352,8 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
     {
         GMX_RELEASE_ASSERT(signal.globalAtomIndices_.has_value(),
                            "Global atom indices required for DD.");
-        auto globalAtomIndices = signal.globalAtomIndices_.value();
-        const int numLocal = signal.x_.size();
+        auto      globalAtomIndices = signal.globalAtomIndices_.value();
+        const int numLocal          = signal.x_.size();
 
         for (int i = 0; i < static_cast<int>(globalAtomIndices.size()); i++)
         {
@@ -364,8 +379,8 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
         const auto* mtaAtoms = options_.params_.mtaAtoms_.get();
         for (int i = 0; i < numInput; i++)
         {
-            int localIndex = mtaAtoms->localIndex()[i];
-            int globalIdx  = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
+            int localIndex         = mtaAtoms->localIndex()[i];
+            int globalIdx          = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
             inputToLocalIndex_[i]  = localIndex;
             inputToGlobalIndex_[i] = globalIdx;
             atomNumbers_[i]        = options_.params_.atoms_.atom[globalIdx].atomnumber;
@@ -425,7 +440,7 @@ void MetatomicForceProvider::preparePairlistInput()
 
         if (inputIdxA.has_value() && inputIdxB.has_value())
         {
-            RVec shift;
+            RVec       shift;
             const IVec unitShift = shiftIndexToXYZ(shiftIndex);
             mvmul_ur0(box_, unitShift.toRVec(), shift);
 
@@ -449,7 +464,8 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
     preparePairlistInput();
 
     // Force tensor - main rank fills, others have zeros
-    torch::Tensor forceTensor = torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
+    torch::Tensor forceTensor =
+            torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
 
     if (mpiComm_.isMainRank())
     {
@@ -460,11 +476,10 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         }
         auto blob_options = torch::TensorOptions().dtype(gromacs_scalar_type).device(torch::kCPU);
 
-        auto torch_positions =
-                torch::from_blob(positions_.data()->as_vec(), { n_atoms, 3 }, blob_options)
-                        .to(data_->dtype)
-                        .to(data_->device)
-                        .set_requires_grad(true);
+        auto torch_positions = torch::from_blob(positions_.data()->as_vec(), { n_atoms, 3 }, blob_options)
+                                       .to(data_->dtype)
+                                       .to(data_->device)
+                                       .set_requires_grad(true);
 
         auto torch_cell =
                 torch::from_blob(&box_, { 3, 3 }, blob_options).to(data_->dtype).to(data_->device);
@@ -480,7 +495,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         for (const auto& request : data_->nl_requests)
         {
             auto neighbors = buildNeighborListFromPairlist(
-                    pairlistForModel_, shiftVectors_, data_->device, data_->dtype);
+                    pairlistForModel_, shiftVectors_, positions_, data_->device, data_->dtype);
             metatomic_torch::register_autograd_neighbors(system, neighbors, false);
             system->add_neighbor_list(request, neighbors);
         }
@@ -508,7 +523,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
                 static_cast<real>(energy_tensor.item<double>());
 
         energy_tensor.backward();
-        auto grad = system->positions().grad();
+        auto grad   = system->positions().grad();
         forceTensor = -grad.to(torch::kCPU).to(torch::kFloat64);
     }
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -497,13 +497,15 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
         // Apply strain to cell: strained_cell = cell @ strain
         auto strained_cell = torch::matmul(torch_cell, strain);
+        // Apply strain to positions: r' = r @ strain
+        auto strained_positions = torch::matmul(torch_positions, strain);
 
         auto torch_pbc = preparePbcType(options_.params_.pbcType_.get(), data_->device);
         auto torch_types =
                 torch::tensor(atomNumbers_, torch::TensorOptions().dtype(torch::kInt32)).to(data_->device);
 
         auto system = torch::make_intrusive<metatomic_torch::SystemHolder>(
-                torch_types, torch_positions, strained_cell, torch_pbc);
+                torch_types, strained_positions, strained_cell, torch_pbc);
 
         // Build neighbor list from GROMACS pairlist
         for (const auto& request : data_->nl_requests)

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -65,6 +65,10 @@
 #include <metatensor/torch.hpp>
 #include <metatomic/torch.hpp>
 
+#if GMX_GPU_CUDA || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_CUDA_TARGET)
+#include <cuda_runtime.h>
+#endif
+
 
 namespace gmx
 {

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -47,23 +47,112 @@
 
 #include "gromacs/domdec/localatomset.h"
 #include "gromacs/mdlib/broadcaststructs.h"
+#include "gromacs/mdrunutility/mdmodulesnotifiers.h"
 #include "gromacs/mdtypes/enerdata.h"
 #include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/pbcutil/ishift.h"
 #include "gromacs/utility/arrayref.h"
 #include "gromacs/utility/exceptions.h"
 #include "gromacs/utility/logger.h"
 #include "gromacs/utility/mpicomm.h"
+#include "gromacs/utility/stringutil.h"
 
 #ifdef DIM
 #    undef DIM
 #endif
-#include <vesin.h>
 
 #include <metatensor/torch.hpp>
 #include <metatomic/torch.hpp>
 
 
-static torch::Tensor preparePbcType(PbcType* pbcType)
+namespace gmx
+{
+
+static std::optional<ptrdiff_t> indexOf(ArrayRef<const int> vec, const int val)
+{
+    auto it = std::find(vec.begin(), vec.end(), val);
+    if (it == vec.end())
+    {
+        return std::nullopt;
+    }
+    return std::distance(vec.begin(), it);
+}
+
+static std::tuple<std::string, std::optional<int>> getMdrunActiveDevice()
+{
+#if GMX_GPU_CUDA || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_CUDA_TARGET)
+    GMX_RELEASE_ASSERT(torch::hasCUDA(), "Libtorch not compiled with CUDA support.");
+    int activeDevice;
+    if (cudaGetDevice(&activeDevice) != cudaSuccess)
+    {
+        GMX_THROW(InternalError("cudaGetDevice failed."));
+    }
+    return { "cuda", activeDevice };
+#elif GMX_GPU_HIP || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_HIP_TARGET)
+#    ifndef USE_ROCM
+    GMX_THROW(InternalError("Libtorch not compiled with HIP support."));
+#    endif
+    int activeDevice;
+    if (hipGetDevice(&activeDevice) != hipSuccess)
+    {
+        GMX_THROW(InternalError("hipGetDevice failed."));
+    }
+    return { "hip", activeDevice };
+#else
+    return { "cpu", std::nullopt };
+#endif
+}
+
+static torch::Device determineDevice(const MDLogger& logger, const MpiComm& mpiComm)
+{
+    torch::Device device(torch::kCPU);
+
+    // Non-main ranks don't run model, return CPU
+    if (!mpiComm.isMainRank())
+    {
+        return device;
+    }
+
+    auto [torchDeviceType, activeDevice] = getMdrunActiveDevice();
+
+    if (const char* env = std::getenv("GMX_METATOMIC_DEVICE"))
+    {
+        const std::string devLC = toLowerCase(env);
+        if (devLC == "gpu" || devLC == "cuda")
+        {
+            if (!torch::cuda::is_available())
+            {
+                GMX_THROW(InternalError(formatString(
+                        "GMX_METATOMIC_DEVICE='%s' but no device available.", env)));
+            }
+            GMX_RELEASE_ASSERT(activeDevice.has_value(), "Could not determine active device.");
+            device = torch::Device(torch::kCUDA, activeDevice.value());
+        }
+        else if (devLC != "cpu")
+        {
+            GMX_THROW(InvalidInputError(formatString(
+                    "GMX_METATOMIC_DEVICE invalid value: '%s'.", env)));
+        }
+        GMX_LOG(logger.info).asParagraph()
+                .appendTextFormatted("Using device from GMX_METATOMIC_DEVICE: '%s'.", env);
+    }
+    else
+    {
+        if (torch::cuda::is_available() && activeDevice.has_value())
+        {
+            GMX_LOG(logger.info).asParagraph()
+                    .appendText("Using " + toUpperCase(torchDeviceType) + " for Metatomic.");
+            device = torch::Device(torch::kCUDA, activeDevice.value());
+        }
+        else
+        {
+            GMX_LOG(logger.info).asParagraph().appendText("Using CPU for Metatomic.");
+        }
+    }
+    return device;
+}
+
+static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
 {
     torch::Tensor pbcTensor =
             torch::tensor({ true, true, true }, torch::TensorOptions().dtype(torch::kBool));
@@ -73,95 +162,37 @@ static torch::Tensor preparePbcType(PbcType* pbcType)
     }
     else if (*pbcType != PbcType::Xyz)
     {
-        GMX_THROW(gmx::InconsistentInputError(
-                "Option use_pbc was set to true, but PBC type is not supported."));
+        GMX_THROW(InconsistentInputError("PBC type not supported."));
     }
-    return pbcTensor;
+    return pbcTensor.to(device);
 }
 
-static metatensor_torch::TensorBlock computeNeighbors(metatomic_torch::NeighborListOptions request,
-                                                      long                                 n_atoms,
-                                                      const float*      positions,
-                                                      const matrix      box,
-                                                      bool              periodic,
-                                                      torch::Device     device,
-                                                      torch::ScalarType dtype)
+static metatensor_torch::TensorBlock buildNeighborListFromPairlist(
+        ArrayRef<const int>  pairlist,
+        ArrayRef<const RVec> shiftVectors,
+        torch::Device        device,
+        torch::ScalarType    dtype)
 {
-    auto cutoff = request->engine_cutoff("nm");
+    const int64_t n_pairs = static_cast<int64_t>(pairlist.size() / 2);
 
-    VesinOptions options;
-    options.cutoff           = cutoff;
-    options.full             = request->full_list();
-    options.return_shifts    = true;
-    options.return_distances = false;
-    options.return_vectors   = true;
-
-    VesinNeighborList* vesin_neighbor_list = new VesinNeighborList();
-
-    double double_box[3][3];
-    for (int i = 0; i < 3; i++)
-    {
-        for (int j = 0; j < 3; j++)
-        {
-            double_box[i][j] = static_cast<double>(box[i][j]);
-        }
-    }
-
-    const size_t        total_elements = static_cast<size_t>(n_atoms) * 3;
-    std::vector<double> double_positions(total_elements);
-
-    for (size_t i = 0; i < total_elements; i++)
-    {
-        double_positions[i] = static_cast<double>(positions[i]);
-    }
-    const double* positions_ptr = double_positions.data();
-
-    VesinDevice cpu{ VesinCPU, 0 };
-    const char* error_message = nullptr;
-    int         status = vesin_neighbors(reinterpret_cast<const double (*)[3]>(positions_ptr),
-                                 static_cast<size_t>(n_atoms),
-                                 double_box,
-                                 &periodic,
-                                 cpu,
-                                 options,
-                                 vesin_neighbor_list,
-                                 &error_message);
-
-    if (status != EXIT_SUCCESS)
-    {
-        std::string err_str = "vesin_neighbors failed: ";
-        if (error_message)
-        {
-            err_str += error_message;
-        }
-        delete vesin_neighbor_list;
-        GMX_THROW(gmx::APIError(err_str));
-    }
-
-    auto n_pairs = static_cast<int64_t>(vesin_neighbor_list->length);
-
-    auto pair_samples_values = torch::empty({ n_pairs, 5 }, torch::TensorOptions().dtype(torch::kInt32));
+    auto pair_samples_values = torch::zeros({ n_pairs, 5 }, torch::TensorOptions().dtype(torch::kInt32));
     auto pair_samples_ptr = pair_samples_values.accessor<int32_t, 2>();
+
+    auto pair_vectors = torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64));
+    auto vectors_accessor = pair_vectors.accessor<double, 3>();
+
     for (int64_t i = 0; i < n_pairs; i++)
     {
-        pair_samples_ptr[i][0] = static_cast<int32_t>(vesin_neighbor_list->pairs[i][0]);
-        pair_samples_ptr[i][1] = static_cast<int32_t>(vesin_neighbor_list->pairs[i][1]);
-        pair_samples_ptr[i][2] = vesin_neighbor_list->shifts[i][0];
-        pair_samples_ptr[i][3] = vesin_neighbor_list->shifts[i][1];
-        pair_samples_ptr[i][4] = vesin_neighbor_list->shifts[i][2];
+        pair_samples_ptr[i][0] = static_cast<int32_t>(pairlist[2 * i]);
+        pair_samples_ptr[i][1] = static_cast<int32_t>(pairlist[2 * i + 1]);
+        pair_samples_ptr[i][2] = 0;
+        pair_samples_ptr[i][3] = 0;
+        pair_samples_ptr[i][4] = 0;
+
+        vectors_accessor[i][0][0] = static_cast<double>(shiftVectors[i][0]);
+        vectors_accessor[i][1][0] = static_cast<double>(shiftVectors[i][1]);
+        vectors_accessor[i][2][0] = static_cast<double>(shiftVectors[i][2]);
     }
-
-    auto deleter = [=](void*)
-    {
-        vesin_free(vesin_neighbor_list);
-        delete vesin_neighbor_list;
-    };
-
-    auto pair_vectors = torch::from_blob(vesin_neighbor_list->vectors,
-                                         { n_pairs, 3, 1 },
-                                         deleter,
-                                         torch::TensorOptions().dtype(torch::kFloat64));
-    pair_vectors.to(dtype);
 
     auto neighbor_samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
             std::vector<std::string>{
@@ -184,8 +215,6 @@ static metatensor_torch::TensorBlock computeNeighbors(metatomic_torch::NeighborL
             neighbor_properties);
 }
 
-namespace gmx
-{
 
 struct MetatomicData
 {
@@ -193,8 +222,8 @@ struct MetatomicData
     metatomic_torch::ModelCapabilities capabilities;
     std::vector<metatomic_torch::NeighborListOptions> nl_requests;
     metatomic_torch::ModelEvaluationOptions           evaluations_options;
-    torch::ScalarType                                 dtype;
-    bool                                              check_consistency;
+    torch::ScalarType                                 dtype  = torch::kFloat32;
+    bool                                              check_consistency = true;
     torch::Device                                     device = torch::kCPU;
 };
 
@@ -207,314 +236,299 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
     box_{ { 0.0, 0.0, 0.0 }, { 0.0, 0.0, 0.0 }, { 0.0, 0.0, 0.0 } },
     data_(std::make_unique<MetatomicData>())
 {
-    // ALL ranks load the model, not just the main rank
-    // This enables each rank to compute forces for its local atoms independently
-    
-    GMX_LOG(logger_.info).asParagraph().appendText("Initializing MetatomicForceProvider on all ranks...");
+    GMX_LOG(logger_.info).asParagraph().appendText("Initializing MetatomicForceProvider...");
 
-    // Load the model on EVERY rank
-    try
-    {
-        torch::optional<std::string> extensions_directory = torch::nullopt;
-        if (!options_.params_.extensionsDirectory.empty())
-        {
-            extensions_directory = options_.params_.extensionsDirectory;
-        }
-
-        this->data_->model = metatomic_torch::load_atomistic_model(options_.params_.modelPath_,
-                                                                   extensions_directory);
-    }
-    catch (const std::exception& e)
-    {
-        GMX_THROW(APIError("Failed to load metatomic model: " + std::string(e.what())));
-    }
-
-    // Query model capabilities on all ranks
-    data_->capabilities =
-            data_->model.run_method("capabilities").toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
-    auto requests_ivalue = data_->model.run_method("requested_neighbor_lists");
-    for (const auto& request_ivalue : requests_ivalue.toList())
-    {
-        data_->nl_requests.push_back(
-                request_ivalue.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>());
-    }
-
-    // Determine device - each rank picks its own device
-    torch::optional<std::string> desired;
-    if (const char* env = std::getenv("GMX_METATOMIC_DEVICE")) {
-        GMX_LOG(logger_.info)
-            .asParagraph()
-            .appendText("Using device from GMX_METATOMIC_DEVICE environment variable: ")
-            .appendText(env);
-        desired = std::string(env);
-    } else {
-        desired = options_.params_.device;
-    }
-
-    c10::DeviceType device_type_ =
-            metatomic_torch::pick_device(data_->capabilities->supported_devices, desired);
-    data_->device = torch::Device(device_type_);
-
-    data_->model.to(data_->device);
-
-    // Set data type on all ranks
-    if (data_->capabilities->dtype() == "float64")
-    {
-        data_->dtype = torch::kFloat64;
-    }
-    else if (data_->capabilities->dtype() == "float32")
-    {
-        data_->dtype = torch::kFloat32;
-    }
-    else
-    {
-        GMX_THROW(APIError("Unsupported dtype from model: " + data_->capabilities->dtype()));
-    }
-
-    // Set up evaluation options on all ranks
-    data_->evaluations_options =
-            torch::make_intrusive<metatomic_torch::ModelEvaluationOptionsHolder>();
-    data_->evaluations_options->set_length_unit("nm");
-
-    auto outputs = data_->capabilities->outputs();
-    if (!outputs.contains("energy"))
-    {
-        GMX_THROW(APIError("Metatomic model must provide an 'energy' output."));
-    }
-
-    auto requested_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
-    requested_output->per_atom = true;  // KEY: Request per-atom energies for proper DD
-    requested_output->explicit_gradients = {};
-
-    data_->evaluations_options->outputs.insert("energy", requested_output);
-
-    data_->check_consistency = options_.params_.checkConsistency;
-
-    // Initialize lookup tables - will be populated on first DD
-    const auto& mtaIndices = options_.params_.mtaIndices_;
-    const int   n_atoms    = static_cast<int>(mtaIndices.size());
-    idxLookup_.resize(n_atoms, -1);
-    atomNumbers_.resize(n_atoms, 0);
-
-    GMX_LOG(logger_.info)
-            .asParagraph()
-            .appendText("MetatomicForceProvider initialization complete on all ranks.");
-}
-
-void MetatomicForceProvider::gatherAtomNumbersIndices()
-{
-    // This function updates the lookup tables after domain decomposition
-    // Each rank knows which ML atoms are local to it
-    
-    const auto& mtaIndices = options_.params_.mtaIndices_;
-    const int   n_atoms    = static_cast<int>(mtaIndices.size());
-
-    // Reset lookup table
-    std::fill(idxLookup_.begin(), idxLookup_.end(), -1);
-
-    // Build reverse lookup: global index -> ML group index
-    std::unordered_map<int, int> globalToMlIndex;
-    globalToMlIndex.reserve(n_atoms);
-    for (int i = 0; i < n_atoms; ++i)
-    {
-        globalToMlIndex[mtaIndices[i]] = i;
-    }
-
-    // Populate lookup for this rank's local atoms
-    const auto* mtaAtoms = options_.params_.mtaAtoms_.get();
-    for (size_t i = 0; i < mtaAtoms->numAtomsLocal(); ++i)
-    {
-        const int lIdx = mtaAtoms->localIndex()[i];
-        const int gIdx = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
-
-        if (auto it = globalToMlIndex.find(gIdx); it != globalToMlIndex.end())
-        {
-            const int mlIdx   = it->second;
-            idxLookup_[mlIdx] = lIdx;
-            atomNumbers_[mlIdx] = options_.params_.atoms_.atom[gIdx].atomnumber;
-        }
-    }
-
-    // For parallel runs, we need all ranks to know ALL atom numbers for the system tensor
-    // But we only compute forces for local atoms
-    // XXX: seems buggy in parallel, need more checks
+    // Pairlist-based neighbor lists don't work with DD yet (indices are local)
+    // Matches NNPot's limitation
     if (mpiComm_.isParallel())
     {
-        // Each rank has partial atomNumbers_, sum to get complete list
-        // This is needed because the System object needs all atom types
-        mpiComm_.sumReduce(gmx::ArrayRef<int>(atomNumbers_.data(), atomNumbers_.data() + n_atoms));
+        GMX_THROW(NotImplementedError(
+                "Metatomic does not yet support domain decomposition. "
+                "Use thread-MPI (gmx mdrun) instead of MPI (mpirun gmx_mpi mdrun)."));
     }
+
+    data_->device = determineDevice(logger_, mpiComm_);
+
+    // Only main rank loads model
+    if (mpiComm_.isMainRank())
+    {
+        try
+        {
+            torch::optional<std::string> extensions_directory = torch::nullopt;
+            if (!options_.params_.extensionsDirectory.empty())
+            {
+                extensions_directory = options_.params_.extensionsDirectory;
+            }
+
+            data_->model = metatomic_torch::load_atomistic_model(options_.params_.modelPath_,
+                                                                 extensions_directory);
+        }
+        catch (const std::exception& e)
+        {
+            GMX_THROW(APIError("Failed to load metatomic model: " + std::string(e.what())));
+        }
+
+        data_->capabilities =
+                data_->model.run_method("capabilities").toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
+
+        auto requests_ivalue = data_->model.run_method("requested_neighbor_lists");
+        for (const auto& request_ivalue : requests_ivalue.toList())
+        {
+            data_->nl_requests.push_back(
+                    request_ivalue.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>());
+        }
+
+        data_->model.to(data_->device);
+
+        if (data_->capabilities->dtype() == "float64")
+        {
+            data_->dtype = torch::kFloat64;
+        }
+        else if (data_->capabilities->dtype() == "float32")
+        {
+            data_->dtype = torch::kFloat32;
+        }
+        else
+        {
+            GMX_THROW(APIError("Unsupported dtype: " + data_->capabilities->dtype()));
+        }
+
+        data_->evaluations_options =
+                torch::make_intrusive<metatomic_torch::ModelEvaluationOptionsHolder>();
+        data_->evaluations_options->set_length_unit("nm");
+
+        auto outputs = data_->capabilities->outputs();
+        if (!outputs.contains("energy"))
+        {
+            GMX_THROW(APIError("Metatomic model must provide 'energy' output."));
+        }
+
+        auto requested_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+        requested_output->per_atom = false;
+        requested_output->explicit_gradients = {};
+
+        data_->evaluations_options->outputs.insert("energy", requested_output);
+        data_->check_consistency = options_.params_.checkConsistency;
+    }
+
+    const auto& mtaIndices = options_.params_.mtaIndices_;
+    const int   n_atoms    = static_cast<int>(mtaIndices.size());
+
+    positions_.resize(n_atoms);
+    atomNumbers_.resize(n_atoms, 0);
+    inputToLocalIndex_.resize(n_atoms, -1);
+    inputToGlobalIndex_.resize(n_atoms, -1);
+
+    GMX_LOG(logger_.info).asParagraph().appendText("MetatomicForceProvider initialization complete.");
 }
 
 MetatomicForceProvider::~MetatomicForceProvider() = default;
 
-void MetatomicForceProvider::gatherAtomPositions(ArrayRef<const RVec> globalPositions)
+void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedistributedSignal& signal)
 {
-    const int n_atoms = static_cast<int>(options_.params_.mtaIndices_.size());
-    positions_.assign(n_atoms, RVec{ 0.0, 0.0, 0.0 });
+    const auto& mtaIndices = options_.params_.mtaIndices_;
+    const int   numInput   = static_cast<int>(mtaIndices.size());
 
-    // Each rank fills its local atoms' positions
-    for (int i = 0; i < n_atoms; ++i)
+    inputToLocalIndex_.assign(numInput, -1);
+    inputToGlobalIndex_.assign(numInput, -1);
+    atomNumbers_.assign(numInput, 0);
+
+    if (mpiComm_.isParallel())
     {
-        if (idxLookup_[i] != -1)
+        GMX_RELEASE_ASSERT(signal.globalAtomIndices_.has_value(),
+                           "Global atom indices required for DD.");
+        auto globalAtomIndices = signal.globalAtomIndices_.value();
+        const int numLocal = signal.x_.size();
+
+        for (int i = 0; i < static_cast<int>(globalAtomIndices.size()); i++)
         {
-            positions_[i] = globalPositions[idxLookup_[i]];
+            int globalIdx = globalAtomIndices[i];
+            for (int j = 0; j < numInput; j++)
+            {
+                if (options_.params_.mtaAtoms_->globalIndex()[j] == globalIdx)
+                {
+                    if (i < numLocal)
+                    {
+                        inputToLocalIndex_[j]  = i;
+                        inputToGlobalIndex_[j] = globalIdx;
+                        atomNumbers_[j]        = options_.params_.atoms_.atom[globalIdx].atomnumber;
+                    }
+                    break;
+                }
+            }
+        }
+        mpiComm_.sumReduce(numInput, atomNumbers_.data());
+    }
+    else
+    {
+        const auto* mtaAtoms = options_.params_.mtaAtoms_.get();
+        for (int i = 0; i < numInput; i++)
+        {
+            int localIndex = mtaAtoms->localIndex()[i];
+            int globalIdx  = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
+            inputToLocalIndex_[i]  = localIndex;
+            inputToGlobalIndex_[i] = globalIdx;
+            atomNumbers_[i]        = options_.params_.atoms_.atom[globalIdx].atomnumber;
         }
     }
 
-    // Sum-reduce positions so all ranks have complete position array
-    // This is needed because neighbor list computation needs all positions
+    GMX_RELEASE_ASSERT(std::count(atomNumbers_.begin(), atomNumbers_.end(), 0) == 0,
+                       "Some atom numbers not set.");
+}
+
+void MetatomicForceProvider::gatherAtomPositions(ArrayRef<const RVec> pos)
+{
+    const size_t numInput = inputToLocalIndex_.size();
+    positions_.assign(numInput, RVec({ 0.0, 0.0, 0.0 }));
+
+    for (size_t i = 0; i < numInput; i++)
+    {
+        if (inputToLocalIndex_[i] != -1)
+        {
+            positions_[i] = pos[inputToLocalIndex_[i]];
+        }
+    }
+
     if (mpiComm_.isParallel())
     {
-        real*        data_ptr = reinterpret_cast<real*>(positions_.data());
-        const size_t n_reals  = static_cast<size_t>(n_atoms) * 3;
-        mpiComm_.sumReduce(gmx::ArrayRef<real>(data_ptr, data_ptr + n_reals));
+        mpiComm_.sumReduce(3 * numInput, positions_.data()->as_vec());
     }
+}
+
+void MetatomicForceProvider::setPairlist(const MDModulesPairlistConstructedSignal& signal)
+{
+    fullPairlist_.assign(signal.excludedPairlist_.begin(), signal.excludedPairlist_.end());
+    doPairlist_ = true;
+}
+
+void MetatomicForceProvider::preparePairlistInput()
+{
+    if (!doPairlist_)
+    {
+        return;
+    }
+
+    GMX_ASSERT(!fullPairlist_.empty(), "Pairlist empty!");
+
+    const int numPairs = gmx::ssize(fullPairlist_);
+    pairlistForModel_.clear();
+    pairlistForModel_.reserve(2 * numPairs);
+    shiftVectors_.clear();
+    shiftVectors_.reserve(numPairs);
+
+    for (int i = 0; i < numPairs; i++)
+    {
+        const auto [atomPair, shiftIndex] = fullPairlist_[i];
+
+        auto inputIdxA = indexOf(inputToGlobalIndex_, atomPair.first);
+        auto inputIdxB = indexOf(inputToGlobalIndex_, atomPair.second);
+
+        if (inputIdxA.has_value() && inputIdxB.has_value())
+        {
+            RVec shift;
+            const IVec unitShift = shiftIndexToXYZ(shiftIndex);
+            mvmul_ur0(box_, unitShift.toRVec(), shift);
+
+            pairlistForModel_.push_back(static_cast<int>(inputIdxA.value()));
+            pairlistForModel_.push_back(static_cast<int>(inputIdxB.value()));
+            shiftVectors_.push_back(shift);
+        }
+    }
+
+    GMX_RELEASE_ASSERT(pairlistForModel_.size() == shiftVectors_.size() * 2,
+                       "Pairlist/shift size mismatch.");
+    doPairlist_ = false;
 }
 
 void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, ForceProviderOutput* outputs)
 {
     const int n_atoms = static_cast<int>(options_.params_.mtaIndices_.size());
 
-    // Gather positions (all ranks need this for neighbor list computation)
-    this->gatherAtomPositions(inputs.x_);
+    gatherAtomPositions(inputs.x_);
     copy_mat(inputs.box_, box_);
+    preparePairlistInput();
 
-    auto gromacs_scalar_type = torch::kFloat32;
-    if (std::is_same_v<real, double>)
-    {
-        gromacs_scalar_type = torch::kFloat64;
-    }
-    auto blob_options = torch::TensorOptions().dtype(gromacs_scalar_type).device(torch::kCPU);
+    // Force tensor - main rank fills, others have zeros
+    torch::Tensor forceTensor = torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
 
-    // ALL ranks run the model, each computing forces for its local atoms
-    auto coerced_positions = makeArrayRef(positions_);
-
-    auto torch_positions =
-            torch::from_blob(coerced_positions.data()->as_vec(), { n_atoms, 3 }, blob_options)
-                    .to(data_->dtype)
-                    .to(data_->device)
-                    .set_requires_grad(true);
-
-    auto torch_cell =
-            torch::from_blob(&box_, { 3, 3 }, blob_options).to(data_->dtype).to(data_->device);
-
-    auto torch_pbc = preparePbcType(options_.params_.pbcType_.get()).to(data_->device);
-    auto torch_types =
-            torch::tensor(atomNumbers_, torch::TensorOptions().dtype(torch::kInt32)).to(data_->device);
-
-    auto system = torch::make_intrusive<metatomic_torch::SystemHolder>(
-            torch_types, torch_positions, torch_cell, torch_pbc);
-
-    bool periodic = torch::all(torch_pbc).item<bool>();
-
-    // Compute neighbor lists on each rank
-    for (const auto& request : data_->nl_requests)
-    {
-        auto neighbors = computeNeighbors(
-                request, n_atoms, coerced_positions.data()->as_vec(), box_, periodic, data_->device, data_->dtype);
-        metatomic_torch::register_autograd_neighbors(system, neighbors, false);
-        system->add_neighbor_list(request, neighbors);
-    }
-
-    // Run the model on EVERY rank
-    metatensor_torch::TensorMap output_map;
-    try
-    {
-        std::vector<metatomic_torch::System> systems;
-        systems.push_back(system);
-
-        auto ivalue_output = data_->model.forward(
-                { c10::IValue(systems), data_->evaluations_options, data_->check_consistency });
-        auto dict_output = ivalue_output.toGenericDict();
-        output_map = dict_output.at("energy").toCustomClass<metatensor_torch::TensorMapHolder>();
-    }
-    catch (const std::exception& e)
-    {
-        GMX_THROW(APIError("[MetatomicPotential] Model evaluation failed: " + std::string(e.what())));
-    }
-
-    // Extract per-atom energies
-    auto energy_block  = metatensor_torch::TensorMapHolder::block_by_id(output_map, 0);
-    auto energy_tensor = energy_block->values();
-
-    // Handle energy for domain decomposition
-    // If per_atom=true, we get per-atom energies [n_atoms, 1]
-    // So sum over local atoms' energies
-    double local_energy = 0.0;
-    
-    if (energy_tensor.dim() == 2 && energy_tensor.size(0) == n_atoms)
-    {
-        // Per-atom energies - sum only local atoms
-        auto energy_cpu = energy_tensor.to(torch::kCPU).to(torch::kFloat64);
-        auto energy_accessor = energy_cpu.accessor<double, 2>();
-        
-        for (int i = 0; i < n_atoms; ++i)
-        {
-            if (idxLookup_[i] != -1)  // Only count local atoms
-            {
-                local_energy += energy_accessor[i][0];
-            }
-        }
-    }
-    else
-    {
-        // Scalar energy - only main rank contributes (or divide among ranks)
-        if (mpiComm_.isMainRank())
-        {
-            local_energy = energy_tensor.item<double>();
-        }
-    }
-
-    // Reduce energy across all ranks
-    double total_energy = local_energy;
-    if (mpiComm_.isParallel())
-    {
-        mpiComm_.sumReduce(gmx::ArrayRef<double>(&total_energy, &total_energy + 1));
-    }
-    
-    // Only main rank sets the energy (GROMACS handles the rest)
     if (mpiComm_.isMainRank())
     {
+        auto gromacs_scalar_type = torch::kFloat32;
+        if (std::is_same_v<real, double>)
+        {
+            gromacs_scalar_type = torch::kFloat64;
+        }
+        auto blob_options = torch::TensorOptions().dtype(gromacs_scalar_type).device(torch::kCPU);
+
+        auto torch_positions =
+                torch::from_blob(positions_.data()->as_vec(), { n_atoms, 3 }, blob_options)
+                        .to(data_->dtype)
+                        .to(data_->device)
+                        .set_requires_grad(true);
+
+        auto torch_cell =
+                torch::from_blob(&box_, { 3, 3 }, blob_options).to(data_->dtype).to(data_->device);
+
+        auto torch_pbc = preparePbcType(options_.params_.pbcType_.get(), data_->device);
+        auto torch_types =
+                torch::tensor(atomNumbers_, torch::TensorOptions().dtype(torch::kInt32)).to(data_->device);
+
+        auto system = torch::make_intrusive<metatomic_torch::SystemHolder>(
+                torch_types, torch_positions, torch_cell, torch_pbc);
+
+        // Build neighbor list from GROMACS pairlist
+        for (const auto& request : data_->nl_requests)
+        {
+            auto neighbors = buildNeighborListFromPairlist(
+                    pairlistForModel_, shiftVectors_, data_->device, data_->dtype);
+            metatomic_torch::register_autograd_neighbors(system, neighbors, false);
+            system->add_neighbor_list(request, neighbors);
+        }
+
+        metatensor_torch::TensorMap output_map;
+        try
+        {
+            std::vector<metatomic_torch::System> systems;
+            systems.push_back(system);
+
+            auto ivalue_output = data_->model.forward(
+                    { c10::IValue(systems), data_->evaluations_options, data_->check_consistency });
+            auto dict_output = ivalue_output.toGenericDict();
+            output_map = dict_output.at("energy").toCustomClass<metatensor_torch::TensorMapHolder>();
+        }
+        catch (const std::exception& e)
+        {
+            GMX_THROW(APIError("[Metatomic] Model evaluation failed: " + std::string(e.what())));
+        }
+
+        auto energy_block  = metatensor_torch::TensorMapHolder::block_by_id(output_map, 0);
+        auto energy_tensor = energy_block->values();
+
         outputs->enerd_.term[InteractionFunction::MetatomicPotentialEnergy] =
-                static_cast<float>(total_energy);
+                static_cast<real>(energy_tensor.item<double>());
+
+        energy_tensor.backward();
+        auto grad = system->positions().grad();
+        forceTensor = -grad.to(torch::kCPU).to(torch::kFloat64);
     }
 
-    // Compute gradients - all ranks do this
-    energy_tensor.sum().backward();
-    auto grad = system->positions().grad();
-    auto forceTensor = -grad.to(torch::kCPU).to(data_->dtype);
+    // Distribute forces (sumReduce acts as broadcast since non-main ranks have zeros)
+    if (mpiComm_.isParallel())
+    {
+        mpiComm_.sumReduce(n_atoms * 3, static_cast<double*>(forceTensor.data_ptr()));
+    }
 
-    // Scatter forces to local atoms ONLY - no broadcast needed!
-    if (data_->dtype == torch::kFloat64)
+    // Apply to local atoms only
+    auto forceAccessor = forceTensor.accessor<double, 2>();
+    for (int i = 0; i < n_atoms; ++i)
     {
-        auto accessor = forceTensor.accessor<double, 2>();
-        for (int i = 0; i < n_atoms; ++i)
+        if (inputToLocalIndex_[i] != -1)
         {
-            const int localIndex = idxLookup_[i];
-            if (localIndex != -1)  // Only update local atoms
-            {
-                outputs->forceWithVirial_.force_[localIndex][0] += accessor[i][0];
-                outputs->forceWithVirial_.force_[localIndex][1] += accessor[i][1];
-                outputs->forceWithVirial_.force_[localIndex][2] += accessor[i][2];
-            }
+            outputs->forceWithVirial_.force_[inputToLocalIndex_[i]][0] += forceAccessor[i][0];
+            outputs->forceWithVirial_.force_[inputToLocalIndex_[i]][1] += forceAccessor[i][1];
+            outputs->forceWithVirial_.force_[inputToLocalIndex_[i]][2] += forceAccessor[i][2];
         }
     }
-    else if (data_->dtype == torch::kFloat32)
-    {
-        auto accessor = forceTensor.accessor<float, 2>();
-        for (int i = 0; i < n_atoms; ++i)
-        {
-            const int localIndex = idxLookup_[i];
-            if (localIndex != -1)  // Only update local atoms
-            {
-                outputs->forceWithVirial_.force_[localIndex][0] += static_cast<double>(accessor[i][0]);
-                outputs->forceWithVirial_.force_[localIndex][1] += static_cast<double>(accessor[i][1]);
-                outputs->forceWithVirial_.force_[localIndex][2] += static_cast<double>(accessor[i][2]);
-            }
-        }
-    }
-    // Note: Virial still needs proper implementation
 }
 
 } // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -84,7 +84,7 @@ static std::optional<ptrdiff_t> indexOf(ArrayRef<const int32_t> vec, const int32
 static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
 {
     torch::Tensor pbcTensor =
-            torch::tensor({ true, true, true }, torch::TensorOptions().dtype(torch::kBool));
+            torch::tensor({ true, true, true }, torch::TensorOptions().dtype(torch::kBool)).device(device);
     if (*pbcType == PbcType::XY)
     {
         pbcTensor[2] = false;
@@ -105,13 +105,16 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<cons
 {
     const int64_t n_pairs = static_cast<int64_t>(pairlist.size() / 2);
 
-    auto pair_samples_values = torch::zeros({ n_pairs, 5 }, torch::TensorOptions().dtype(torch::kInt32));
+    auto pair_samples_values =
+            torch::zeros({ n_pairs, 5 }, torch::TensorOptions().dtype(torch::kInt32)).device(device);
     auto pair_samples_ptr = pair_samples_values.accessor<int32_t, 2>();
 
     // Full interatomic vectors (rj - ri + shift), not just shifts.
-    auto pair_vectors = torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64));
+    auto pair_vectors =
+            torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64)).device(device);
 
-    auto vectors_cpu = torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64));
+    auto vectors_cpu =
+            torch::zeros({ n_pairs, 3, 1 }, torch::TensorOptions().dtype(torch::kFloat64)).device(device);
     auto vectors_accessor = vectors_cpu.accessor<double, 3>();
 
     for (int64_t i = 0; i < n_pairs; i++)
@@ -409,7 +412,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
     // Force tensor - main rank fills, others have zeros
     torch::Tensor forceTensor =
-            torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
+            torch::zeros({ n_atoms, 3 }, torch::TensorOptions().dtype(torch::kFloat64)).device(data_->device);
 
     // Virial tensor for pressure/stress calculations
     torch::Tensor virialTensor = torch::zeros({ 3, 3 }, torch::TensorOptions().dtype(torch::kFloat64));
@@ -421,7 +424,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         {
             gromacs_scalar_type = torch::kFloat64;
         }
-        auto blob_options = torch::TensorOptions().dtype(gromacs_scalar_type).device(torch::kCPU);
+        auto blob_options = torch::TensorOptions().dtype(gromacs_scalar_type).device(data_->device);
 
         auto torch_positions = torch::from_blob(positions_.data()->as_vec(), { n_atoms, 3 }, blob_options)
                                        .to(data_->dtype)

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -98,6 +98,7 @@ static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
 
 static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<const int32_t> pairlist,
                                                                    ArrayRef<const RVec> shiftVectors,
+                                                                   ArrayRef<const RVec> cellShifts,
                                                                    ArrayRef<const RVec> positions,
                                                                    torch::Device        device,
                                                                    torch::ScalarType    dtype)
@@ -120,9 +121,9 @@ static metatensor_torch::TensorBlock buildNeighborListFromPairlist(ArrayRef<cons
 
         pair_samples_ptr[i][0] = static_cast<int32_t>(atom_i);
         pair_samples_ptr[i][1] = static_cast<int32_t>(atom_j);
-        pair_samples_ptr[i][2] = 0;
-        pair_samples_ptr[i][3] = 0;
-        pair_samples_ptr[i][4] = 0;
+        pair_samples_ptr[i][2] = cellShifts[i][0];
+        pair_samples_ptr[i][3] = cellShifts[i][1];
+        pair_samples_ptr[i][4] = cellShifts[i][2];
 
         // Calculate r_ij = r_j - r_i + shift
         double r_ij_x = positions[atom_j][0] - positions[atom_i][0] + shiftVectors[i][0];
@@ -291,7 +292,7 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
     if (mpiComm_.isParallel())
     {
         GMX_RELEASE_ASSERT(signal.globalAtomIndices_.has_value(),
-                           "Global atom indices required for DD.");
+                           "Global atom indices required for domain decomposition.");
         auto          globalAtomIndices = signal.globalAtomIndices_.value();
         const int32_t numLocal          = signal.x_.size();
 
@@ -370,6 +371,8 @@ void MetatomicForceProvider::preparePairlistInput()
     pairlistForModel_.reserve(2 * numPairs);
     shiftVectors_.clear();
     shiftVectors_.reserve(numPairs);
+    cellShifts_.clear();
+    cellShifts_.reserve(numPairs);
 
     for (int32_t i = 0; i < numPairs; i++)
     {
@@ -387,6 +390,7 @@ void MetatomicForceProvider::preparePairlistInput()
             pairlistForModel_.push_back(static_cast<int32_t>(inputIdxA.value()));
             pairlistForModel_.push_back(static_cast<int32_t>(inputIdxB.value()));
             shiftVectors_.push_back(shift);
+            cellShifts_.push_back(unitShift);
         }
     }
 
@@ -447,7 +451,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         for (const auto& request : data_->nl_requests)
         {
             auto neighbors = buildNeighborListFromPairlist(
-                    pairlistForModel_, shiftVectors_, positions_, data_->device, data_->dtype);
+                    pairlistForModel_, shiftVectors_, cellShifts_, positions_, data_->device, data_->dtype);
             // TODO: take from the user / model
             metatomic_torch::register_autograd_neighbors(system, neighbors, /*check_consistency*/ true);
             system->add_neighbor_list(request, neighbors);

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -44,8 +44,6 @@
 
 #include <cstdint>
 
-#include <unordered_map>
-
 #include "gromacs/domdec/localatomset.h"
 #include "gromacs/mdlib/broadcaststructs.h"
 #include "gromacs/mdrunutility/mdmodulesnotifiers.h"
@@ -81,81 +79,6 @@ static std::optional<ptrdiff_t> indexOf(ArrayRef<const int32_t> vec, const int32
         return std::nullopt;
     }
     return std::distance(vec.begin(), it);
-}
-
-static std::tuple<std::string, std::optional<int32_t>> getMdrunActiveDevice()
-{
-#if GMX_GPU_CUDA || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_CUDA_TARGET)
-    GMX_RELEASE_ASSERT(torch::hasCUDA(), "Libtorch not compiled with CUDA support.");
-    int32_t activeDevice;
-    if (cudaGetDevice(&activeDevice) != cudaSuccess)
-    {
-        GMX_THROW(InternalError("cudaGetDevice failed."));
-    }
-    return { "cuda", activeDevice };
-#elif GMX_GPU_HIP || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_HIP_TARGET)
-#    ifndef USE_ROCM
-    GMX_THROW(InternalError("Libtorch not compiled with HIP support."));
-#    endif
-    int32_t activeDevice;
-    if (hipGetDevice(&activeDevice) != hipSuccess)
-    {
-        GMX_THROW(InternalError("hipGetDevice failed."));
-    }
-    return { "hip", activeDevice };
-#else
-    return { "cpu", std::nullopt };
-#endif
-}
-
-static torch::Device determineDevice(const MDLogger& logger, const MpiComm& mpiComm)
-{
-    torch::Device device(torch::kCPU);
-
-    // Non-main ranks don't run model, return CPU
-    if (!mpiComm.isMainRank())
-    {
-        return device;
-    }
-
-    auto [torchDeviceType, activeDevice] = getMdrunActiveDevice();
-
-    if (const char* env = std::getenv("GMX_METATOMIC_DEVICE"))
-    {
-        const std::string devLC = toLowerCase(env);
-        if (devLC == "gpu" || devLC == "cuda")
-        {
-            if (!torch::cuda::is_available())
-            {
-                GMX_THROW(InternalError(
-                        formatString("GMX_METATOMIC_DEVICE='%s' but no device available.", env)));
-            }
-            GMX_RELEASE_ASSERT(activeDevice.has_value(), "Could not determine active device.");
-            device = torch::Device(torch::kCUDA, activeDevice.value());
-        }
-        else if (devLC != "cpu")
-        {
-            GMX_THROW(InvalidInputError(formatString("GMX_METATOMIC_DEVICE invalid value: '%s'.", env)));
-        }
-        GMX_LOG(logger.info)
-                .asParagraph()
-                .appendTextFormatted("Using device from GMX_METATOMIC_DEVICE: '%s'.", env);
-    }
-    else
-    {
-        if (torch::cuda::is_available() && activeDevice.has_value())
-        {
-            GMX_LOG(logger.info)
-                    .asParagraph()
-                    .appendText("Using " + toUpperCase(torchDeviceType) + " for Metatomic.");
-            device = torch::Device(torch::kCUDA, activeDevice.value());
-        }
-        else
-        {
-            GMX_LOG(logger.info).asParagraph().appendText("Using CPU for Metatomic.");
-        }
-    }
-    return device;
 }
 
 static torch::Tensor preparePbcType(PbcType* pbcType, torch::Device device)
@@ -255,7 +178,7 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
 {
     GMX_LOG(logger_.info).asParagraph().appendText("Initializing MetatomicForceProvider...");
 
-    // Pairlist-based neighbor lists don't work with DD yet (indices are local)
+    // Pairlist-based neighbor lists don't work with domain decomposition yet (indices are local)
     // Matches NNPot's limitation
     if (mpiComm_.isParallel())
     {
@@ -263,8 +186,6 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
                 "Metatomic does not yet support domain decomposition. "
                 "Use thread-MPI (gmx mdrun) instead of MPI (mpirun gmx_mpi mdrun)."));
     }
-
-    data_->device = determineDevice(logger_, mpiComm_);
 
     // Only main rank loads model
     if (mpiComm_.isMainRank())
@@ -287,6 +208,21 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
 
         data_->capabilities =
                 data_->model.run_method("capabilities").toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
+
+        // Determine device using capabilities and optional environment variable
+        torch::optional<std::string> desiredDevice = torch::nullopt;
+        if (const char* env = std::getenv("GMX_METATOMIC_DEVICE"))
+        {
+            desiredDevice = std::string(env);
+        }
+
+        const auto deviceType =
+                metatomic_torch::pick_device(data_->capabilities->supported_devices, desiredDevice);
+        data_->device = torch::Device(deviceType);
+
+        GMX_LOG(logger_.info)
+                .asParagraph()
+                .appendTextFormatted("Metatomic using device: %s", data_->device.str().c_str());
 
         auto requests_ivalue = data_->model.run_method("requested_neighbor_lists");
         for (const auto& request_ivalue : requests_ivalue.toList())
@@ -328,8 +264,8 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
         data_->check_consistency = options_.params_.checkConsistency;
     }
 
-    const auto& mtaIndices = options_.params_.mtaIndices_;
-    const int32_t   n_atoms    = static_cast<int32_t>(mtaIndices.size());
+    const auto&   mtaIndices = options_.params_.mtaIndices_;
+    const int32_t n_atoms    = static_cast<int32_t>(mtaIndices.size());
 
     positions_.resize(n_atoms);
     atomNumbers_.resize(n_atoms, 0);
@@ -345,8 +281,8 @@ MetatomicForceProvider::~MetatomicForceProvider() = default;
 
 void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedistributedSignal& signal)
 {
-    const auto& mtaIndices = options_.params_.mtaIndices_;
-    const int32_t   numInput   = static_cast<int32_t>(mtaIndices.size());
+    const auto&   mtaIndices = options_.params_.mtaIndices_;
+    const int32_t numInput   = static_cast<int32_t>(mtaIndices.size());
 
     inputToLocalIndex_.assign(numInput, -1);
     inputToGlobalIndex_.assign(numInput, -1);
@@ -356,7 +292,7 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
     {
         GMX_RELEASE_ASSERT(signal.globalAtomIndices_.has_value(),
                            "Global atom indices required for DD.");
-        auto      globalAtomIndices = signal.globalAtomIndices_.value();
+        auto          globalAtomIndices = signal.globalAtomIndices_.value();
         const int32_t numLocal          = signal.x_.size();
 
         for (int32_t i = 0; i < static_cast<int32_t>(globalAtomIndices.size()); i++)
@@ -383,8 +319,8 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
         const auto* mtaAtoms = options_.params_.mtaAtoms_.get();
         for (int32_t i = 0; i < numInput; i++)
         {
-            int32_t localIndex         = mtaAtoms->localIndex()[i];
-            int32_t globalIdx          = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
+            int32_t localIndex     = mtaAtoms->localIndex()[i];
+            int32_t globalIdx      = mtaAtoms->globalIndex()[mtaAtoms->collectiveIndex()[i]];
             inputToLocalIndex_[i]  = localIndex;
             inputToGlobalIndex_[i] = globalIdx;
             atomNumbers_[i]        = options_.params_.atoms_.atom[globalIdx].atomnumber;
@@ -512,7 +448,8 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         {
             auto neighbors = buildNeighborListFromPairlist(
                     pairlistForModel_, shiftVectors_, positions_, data_->device, data_->dtype);
-            metatomic_torch::register_autograd_neighbors(system, neighbors, false);
+            // TODO: take from the user / model
+            metatomic_torch::register_autograd_neighbors(system, neighbors, /*check_consistency*/ true);
             system->add_neighbor_list(request, neighbors);
         }
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -59,14 +59,14 @@
 #include "gromacs/utility/stringutil.h"
 
 #ifdef DIM
-#undef DIM
+#    undef DIM
 #endif
 
 #include <metatensor/torch.hpp>
 #include <metatomic/torch.hpp>
 
 #if GMX_GPU_CUDA || (GMX_SYCL_ACPP && GMX_ACPP_HAVE_CUDA_TARGET)
-#include <cuda_runtime.h>
+#    include <cuda_runtime.h>
 #endif
 
 
@@ -571,14 +571,18 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
     // Apply virial contribution
     // GROMACS uses a 3x3 virial tensor in forceWithVirial_
-    auto virialAccessor = virialTensor.accessor<double, 2>();
+    // Copy the tensor data into a GROMACS matrix and use the public API
+    matrix virialMatrix;
+    auto   virialAccessor = virialTensor.accessor<double, 2>();
+    // TODO: technically this is DIM, not 3...
     for (int i = 0; i < 3; ++i)
     {
         for (int j = 0; j < 3; ++j)
         {
-            outputs->forceWithVirial_.virial_[i][j] += virialAccessor[i][j];
+            virialMatrix[i][j] = virialAccessor[i][j];
         }
     }
+    outputs->forceWithVirial_.addVirialContribution(virialMatrix);
 }
 
 } // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
@@ -118,6 +118,9 @@ private:
     //! Shift vectors for each atom pair in pairlistForModel_
     std::vector<RVec> shiftVectors_;
 
+    //! Cell shifts
+    std::vector<RVec> cellShifts_;
+
     //! local copy of simulation box
     matrix box_;
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
@@ -50,9 +50,16 @@ namespace gmx
 
 struct MetatomicParameters;
 struct MetatomicData;
+struct MDModulesAtomsRedistributedSignal;
+struct MDModulesPairlistConstructedSignal;
 
 class MDLogger;
 class MpiComm;
+
+/*! For compatibility with pairlist data structure in MDModulesPairlistConstructedSignal.
+ * Contains pairs like ((atom1, atom2), shiftIndex).
+ */
+using PairlistEntry = std::pair<std::pair<int, int>, int>;
 
 /*! \brief \internal
  * MetatomicForceProvider class
@@ -72,28 +79,53 @@ public:
      * \param[out] fOutput output for force provider
      */
     void calculateForces(const ForceProviderInput& inputs, ForceProviderOutput* outputs) override;
-    void updateLocalAtoms();
-    void gatherAtomPositions(ArrayRef<const RVec> globalPositions);
-    void gatherAtomNumbersIndices();
+
+    //! Gather atom numbers and indices. Triggered on AtomsRedistributed signal.
+    void gatherAtomNumbersIndices(const MDModulesAtomsRedistributedSignal& signal);
+
+    //! Set pairlist from notification and filter to MTA atom pairs.
+    void setPairlist(const MDModulesPairlistConstructedSignal& signal);
 
 private:
+    //! Gather atom positions for MTA input.
+    void gatherAtomPositions(ArrayRef<const RVec> globalPositions);
+
+    //! Prepare pairlist input for model
+    void preparePairlistInput();
+
     const MetatomicOptions& options_;
     const MDLogger&         logger_;
     const MpiComm&          mpiComm_;
 
-    //! vector storing all atom positions
+    //! vector storing all MTA atom positions
     std::vector<RVec> positions_;
 
     //! vector storing all atomic numbers
     std::vector<int> atomNumbers_;
 
-    //! global index lookup table to map indices from model input to global atom indices
-    std::vector<int> idxLookup_;
+    //! lookup table to map model input indices [0...numInput) to local atom indices
+    std::vector<int> inputToLocalIndex_;
+
+    //! lookup table to map model input indices to global atom indices
+    std::vector<int> inputToGlobalIndex_;
+
+    //! Full pairlist from MDModules notification
+    std::vector<PairlistEntry> fullPairlist_;
+
+    //! Interacting pairs of MTA atoms within cutoff, for model input
+    std::vector<int> pairlistForModel_;
+
+    //! Shift vectors for each atom pair in pairlistForModel_
+    std::vector<RVec> shiftVectors_;
 
     //! local copy of simulation box
     matrix box_;
+
     //! Data required for metatomic calculations
     std::unique_ptr<MetatomicData> data_;
+
+    //! flag to check if pairlist data should be prepared
+    bool doPairlist_ = false;
 };
 
 } // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
@@ -59,7 +59,7 @@ class MpiComm;
 /*! For compatibility with pairlist data structure in MDModulesPairlistConstructedSignal.
  * Contains pairs like ((atom1, atom2), shiftIndex).
  */
-using PairlistEntry = std::pair<std::pair<int, int>, int>;
+using PairlistEntry = std::pair<std::pair<int32_t, int32_t>, int32_t>;
 
 /*! \brief \internal
  * MetatomicForceProvider class
@@ -101,19 +101,19 @@ private:
     std::vector<RVec> positions_;
 
     //! vector storing all atomic numbers
-    std::vector<int> atomNumbers_;
+    std::vector<int32_t> atomNumbers_;
 
     //! lookup table to map model input indices [0...numInput) to local atom indices
-    std::vector<int> inputToLocalIndex_;
+    std::vector<int32_t> inputToLocalIndex_;
 
     //! lookup table to map model input indices to global atom indices
-    std::vector<int> inputToGlobalIndex_;
+    std::vector<int32_t> inputToGlobalIndex_;
 
     //! Full pairlist from MDModules notification
     std::vector<PairlistEntry> fullPairlist_;
 
     //! Interacting pairs of MTA atoms within cutoff, for model input
-    std::vector<int> pairlistForModel_;
+    std::vector<int32_t> pairlistForModel_;
 
     //! Shift vectors for each atom pair in pairlistForModel_
     std::vector<RVec> shiftVectors_;

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
@@ -119,7 +119,7 @@ private:
     std::vector<RVec> shiftVectors_;
 
     //! Cell shifts
-    std::vector<RVec> cellShifts_;
+    std::vector<IVec> cellShifts_;
 
     //! local copy of simulation box
     matrix box_;

--- a/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
@@ -53,6 +53,12 @@
 
 #include "metatomic_forceprovider.h"
 #include "metatomic_options.h"
+#ifdef DIM
+#    undef DIM
+#endif
+
+#include <metatensor/torch.hpp>
+#include <metatomic/torch.hpp>
 
 namespace gmx
 {
@@ -171,9 +177,34 @@ public:
 
         const auto setPlainPairlistRangeFunction = [this](PlainPairlistRanges* ranges)
         {
-            // XXX: take the real cutoff..
-            float cutoff = 0.576;
-            ranges->addRange(cutoff);
+            // Temporary: Load model just to peek at cutoff.
+            // Optimization: move this to MetatomicOptions::checkNNPotModel equivalent later.
+            double req_cutoff = 0.0;
+            try
+            {
+                auto model = metatomic_torch::load_atomistic_model(options_.parameters().modelPath_);
+                auto requests = model.run_method("requested_neighbor_lists");
+                for (const auto& req : requests.toList())
+                {
+                    auto opts = req.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
+                    double c = opts->engine_cutoff("nm");
+                    if (c > req_cutoff)
+                        req_cutoff = c;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                GMX_THROW(InternalError("Failed to read cutoff from model: " + std::string(e.what())));
+            }
+
+            if (req_cutoff <= 0.0)
+            {
+                // Fallback or error
+                GMX_THROW(InconsistentInputError(
+                        "Metatomic model requested 0.0 or negative cutoff."));
+            }
+
+            ranges->addRange(req_cutoff);
         };
         notifiers->simulationSetupNotifier_.subscribe(setPlainPairlistRangeFunction);
     }

--- a/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
@@ -49,6 +49,7 @@
 #include "gromacs/mdrunutility/mdmodulesnotifiers.h"
 #include "gromacs/mdrunutility/plainpairlistranges.h"
 #include "gromacs/mdtypes/imdmodule.h"
+#include "gromacs/utility/basenetwork.h"
 #include "gromacs/utility/keyvaluetreebuilder.h"
 
 #include "metatomic_forceprovider.h"
@@ -56,6 +57,8 @@
 #ifdef DIM
 #    undef DIM
 #endif
+
+#include <cmath>
 
 #include <metatensor/torch.hpp>
 #include <metatomic/torch.hpp>
@@ -178,18 +181,41 @@ public:
         const auto setPlainPairlistRangeFunction = [this](PlainPairlistRanges* ranges)
         {
             // Temporary: Load model just to peek at cutoff.
-            // Optimization: move this to MetatomicOptions::checkNNPotModel equivalent later.
-            double req_cutoff = 0.0;
+            // TODO: can the whole model be loaded earlier..? 
+            double max_cutoff{ 0.0 };
             try
             {
                 auto model = metatomic_torch::load_atomistic_model(options_.parameters().modelPath_);
-                auto requests = model.run_method("requested_neighbor_lists");
-                for (const auto& req : requests.toList())
+                auto capabilities =
+                        model.run_method("capabilities").toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
+                double interaction_range = capabilities->engine_interaction_range("nm");
+                if (interaction_range < 0.0)
                 {
-                    auto opts = req.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
-                    double c = opts->engine_cutoff("nm");
-                    if (c > req_cutoff)
-                        req_cutoff = c;
+                    GMX_THROW(InconsistentInputError(
+                            "interaction_range is negative for this model."));
+                }
+
+                if (!std::isfinite(interaction_range))
+                {
+                    if (gmx_node_num() > 1)
+                    {
+                        GMX_THROW(NotImplementedError(
+                                "interaction_range is infinite for this model; "
+                                "using multiple MPI domains is not supported."));
+                    }
+
+                    auto requested_nl = model.run_method("requested_neighbor_lists");
+                    for (const auto& ivalue : requested_nl.toList())
+                    {
+                        auto options =
+                                ivalue.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
+                        double cutoff = options->engine_cutoff("nm");
+                        max_cutoff    = std::max(max_cutoff, cutoff);
+                    }
+                }
+                else
+                {
+                    max_cutoff = interaction_range;
                 }
             }
             catch (const std::exception& e)
@@ -197,14 +223,13 @@ public:
                 GMX_THROW(InternalError("Failed to read cutoff from model: " + std::string(e.what())));
             }
 
-            if (req_cutoff <= 0.0)
+            if (max_cutoff <= 0.0 || !std::isfinite(max_cutoff))
             {
-                // Fallback or error
                 GMX_THROW(InconsistentInputError(
                         "Metatomic model requested 0.0 or negative cutoff."));
             }
 
-            ranges->addRange(req_cutoff);
+            ranges->addRange(max_cutoff);
         };
         notifiers->simulationSetupNotifier_.subscribe(setPlainPairlistRangeFunction);
     }

--- a/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
@@ -175,6 +175,7 @@ public:
      *
      * The Metatomic module subscribes to the following notifications:
      * - Atom redistribution due to domain decomposition
+     * - Changes in the neighborlist
      * by taking a const MDModulesAtomsRedistributedSignal as a parameter.
      */
     void subscribeToSimulationRunNotifications(MDModulesNotifiers* notifiers) override
@@ -185,10 +186,14 @@ public:
         }
 
         // After domain decomposition, the force provider needs to know which atoms are local.
-        const auto notifyDDFunction = [this](const MDModulesAtomsRedistributedSignal& /*signal*/) {
-            force_provider_->gatherAtomNumbersIndices();
-        };
+        const auto notifyDDFunction = [this](const MDModulesAtomsRedistributedSignal& signal)
+        { force_provider_->gatherAtomNumbersIndices(signal); };
         notifiers->simulationRunNotifier_.subscribe(notifyDDFunction);
+
+        // subscribe to pairlist construction notification
+        const auto notifyPairlistFunction = [this](const MDModulesPairlistConstructedSignal& signal)
+        { force_provider_->setPairlist(signal); };
+        notifiers->simulationRunNotifier_.subscribe(notifyPairlistFunction);
     }
 
     void initForceProviders(ForceProviders* forceProviders) override
@@ -199,8 +204,7 @@ public:
         }
 
         force_provider_ = std::make_unique<MetatomicForceProvider>(
-                options_, options_.logger(), options_.mpiComm()
-        );
+                options_, options_.logger(), options_.mpiComm());
         forceProviders->addForceProvider(force_provider_.get(), "Metatomic");
     }
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
@@ -47,6 +47,7 @@
 #include "gromacs/domdec/localatomset.h"
 #include "gromacs/domdec/localatomsetmanager.h"
 #include "gromacs/mdrunutility/mdmodulesnotifiers.h"
+#include "gromacs/mdrunutility/plainpairlistranges.h"
 #include "gromacs/mdtypes/imdmodule.h"
 #include "gromacs/utility/keyvaluetreebuilder.h"
 
@@ -167,6 +168,14 @@ public:
                 [](MDModulesEnergyOutputToMetatomicPotRequestChecker* energyOutputRequest)
         { energyOutputRequest->energyOutputToMetatomicPot_ = true; };
         notifiers->simulationSetupNotifier_.subscribe(requestEnergyOutput);
+
+        const auto setPlainPairlistRangeFunction = [this](PlainPairlistRanges* ranges)
+        {
+            // XXX: take the real cutoff..
+            float cutoff = 0.576;
+            ranges->addRange(cutoff);
+        };
+        notifiers->simulationSetupNotifier_.subscribe(setPlainPairlistRangeFunction);
     }
 
     /*! \brief Requests to be notified during the simulation.

--- a/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
@@ -181,14 +181,17 @@ public:
         const auto setPlainPairlistRangeFunction = [this](PlainPairlistRanges* ranges)
         {
             // Temporary: Load model just to peek at cutoff.
-            // TODO: can the whole model be loaded earlier..? 
+            // TODO: can the whole model be loaded earlier..?
             double max_cutoff{ 0.0 };
             try
             {
                 auto model = metatomic_torch::load_atomistic_model(options_.parameters().modelPath_);
+
+                // Check strict interaction range
                 auto capabilities =
                         model.run_method("capabilities").toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
                 double interaction_range = capabilities->engine_interaction_range("nm");
+
                 if (interaction_range < 0.0)
                 {
                     GMX_THROW(InconsistentInputError(
@@ -197,25 +200,29 @@ public:
 
                 if (!std::isfinite(interaction_range))
                 {
+                    // Infinite range (global) is only supported on a single rank
                     if (gmx_node_num() > 1)
                     {
                         GMX_THROW(NotImplementedError(
                                 "interaction_range is infinite for this model; "
                                 "using multiple MPI domains is not supported."));
                     }
-
-                    auto requested_nl = model.run_method("requested_neighbor_lists");
-                    for (const auto& ivalue : requested_nl.toList())
-                    {
-                        auto options =
-                                ivalue.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
-                        double cutoff = options->engine_cutoff("nm");
-                        max_cutoff    = std::max(max_cutoff, cutoff);
-                    }
+                    // For infinite range, check if specific NLs were requested
+                    // effectively falling through to the loop below.
                 }
                 else
                 {
                     max_cutoff = interaction_range;
+                }
+
+                // Check requested neighbor lists
+                auto requested_nl = model.run_method("requested_neighbor_lists");
+                for (const auto& ivalue : requested_nl.toList())
+                {
+                    auto options =
+                            ivalue.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
+                    double cutoff = options->engine_cutoff("nm");
+                    max_cutoff    = std::max(max_cutoff, cutoff);
                 }
             }
             catch (const std::exception& e)
@@ -225,12 +232,17 @@ public:
 
             if (max_cutoff <= 0.0 || !std::isfinite(max_cutoff))
             {
-                GMX_THROW(InconsistentInputError(
-                        "Metatomic model requested 0.0 or negative cutoff."));
+                // If the model is purely global and requested no specific NL,
+                // there's no need for a pairlist, so max_cutoff remains 0.
+                if (max_cutoff == 0.0)
+                {
+                    GMX_THROW(InconsistentInputError("Metatomic model cutoff is 0.0 or invalid."));
+                }
             }
-
+            // Register the requirement with GROMACS
             ranges->addRange(max_cutoff);
         };
+        // Register the callback
         notifiers->simulationSetupNotifier_.subscribe(setPlainPairlistRangeFunction);
     }
 

--- a/src/gromacs/applied_forces/metatomic/tests/metatomic_options.cpp
+++ b/src/gromacs/applied_forces/metatomic/tests/metatomic_options.cpp
@@ -34,9 +34,9 @@
  */
 /*! \internal \file
  * \brief
- * Tests for functionality of the NNPotOptions
+ * Tests for functionality of the MetatomicOptions
  *
- * \author Lukas Müllender <lukas.muellender@gmail.com>
+ * \author Metatensor developers <https://github.com/metatensor>
  * \ingroup module_applied_forces
  */
 

--- a/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_DefaultParameters.xml
+++ b/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_DefaultParameters.xml
@@ -2,10 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="referencedata.xsl"?>
 <ReferenceData>
   <Bool Name="active">false</Bool>
-  <String Name="modelFileName">model.pt</String>
-  <String Name="input-group">System</String>
-  <String Name="model"></String>
-  <String Name="extensions"></String>
-  <String Name="check-consistency"></String>
+  <String Name="inputGroup">System</String>
+  <String Name="modelPath"></String>
+  <String Name="extensionsDirectory"></String>
   <String Name="device"></String>
+  <Bool Name="checkConsistency">true</Bool>
 </ReferenceData>

--- a/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_OutputDefaultValuesWhenActive.xml
+++ b/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_OutputDefaultValuesWhenActive.xml
@@ -3,11 +3,11 @@
 <ReferenceData>
   <String Name="Mdp output">
 ; Machine learning potential using metatomic
-metatomic-active             = true
-metatomic-input-group        = System
-metatomic-model              = 
-metatomic-extensions         = 
-metatomic-device             = 
-metatomic-check-consistency  = true
+metatomic-active         = true
+metatomic-input-group    = System
+metatomic-model          = 
+metatomic-extensions     = 
+metatomic-device         = 
+metatomic-check-consistency = true
 </String>
 </ReferenceData>

--- a/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_OutputNoDefaultValuesWhenInactive.xml
+++ b/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_OutputNoDefaultValuesWhenInactive.xml
@@ -3,6 +3,6 @@
 <ReferenceData>
   <String Name="Mdp output">
 ; Machine learning potential using metatomic
-metatomic-active             = false
+metatomic-active         = false
 </String>
 </ReferenceData>


### PR DESCRIPTION
No `vesin` involved, so should be good for upstream too. Also got faster... and takes the cutoff from the model, so win-win.

```
Core t (s)   Wall t (s)        (%)
       Time:        4.751        0.297     1599.8
                 (ns/day)    (hour/ns)    (ms/step)  (Matom*steps/s) 
Performance:       29.382        0.817        2.941            0.043
```

So 2x the first `vesin` version.

Same design as #1.

For instructions on optimal usage / reproduction consider [details here](https://github.com/HaoZeke/pixi_envs/tree/main/orgs/metatensor/gromacs).