### PR TITLE
perf(mta): fix DD scalability bottlenecks + ASV benchmarks

### DIFF
--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -68,6 +68,7 @@
 #include "gromacs/domdec/domdec_network.h"
 #include "gromacs/domdec/domdec_struct.h"
 #include "gromacs/domdec/localatomset.h"
+#include "gromacs/math/boxmatrix.h"
 #include "gromacs/mdlib/broadcaststructs.h"
 #include "gromacs/mdrunutility/mdmodulesnotifiers.h"
 #include "gromacs/mdtypes/enerdata.h"
@@ -152,6 +153,8 @@ struct MetatomicData
     torch::Tensor cachedTypes;
     torch::Tensor cachedPbc;
 
+    //! Sparse/dense force exchange threshold (atom count). Env: GMX_METATOMIC_SPARSE_THRESHOLD.
+    int32_t sparseThreshold = 1000;
 };
 
 MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
@@ -171,6 +174,15 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
     }
 
     data_->debugEnabled = (std::getenv("GMX_METATOMIC_DEBUG") != nullptr);
+
+    if (const char* env = std::getenv("GMX_METATOMIC_SPARSE_THRESHOLD"))
+    {
+        data_->sparseThreshold = std::stoi(env);
+        GMX_LOG(logger_.info)
+                .asParagraph()
+                .appendTextFormatted("Metatomic sparse force threshold: %d",
+                                     data_->sparseThreshold);
+    }
 
     // Force single-threaded PyTorch operations in all parallel runs.
     // In thread-MPI, ranks share a process; in real MPI, each rank is a process.
@@ -710,7 +722,7 @@ int32_t MetatomicForceProvider::exchangeBackwardGhosts(
 }
 
 
-void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
+void MetatomicForceProvider::exchangeBackwardPairs(const matrix box, int maxRounds)
 {
     backwardPairsMta_.clear();
     backwardShiftsMta_.clear();
@@ -772,10 +784,14 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
     const int sendTo   = (myRank + 1) % numRanks;
     const int recvFrom = (myRank - 1 + numRanks) % numRanks;
 
+    // Compute box inverse once for triclinic-safe shift computation.
+    matrix boxInv;
+    invertBoxMatrix(box, boxInv);
+
     std::vector<int> sendBuf = myPairsBuf;
     std::vector<int> recvBuf;
 
-    for (int round = 0; round < numRanks - 1; round++)
+    for (int round = 0; round < maxRounds; round++)
     {
         // Exchange counts first so receiver knows buffer size.
         int sendCount = static_cast<int>(sendBuf.size());
@@ -820,7 +836,8 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
             const int32_t localI = itI->second;
             const int32_t localJ = itJ->second;
 
-            // Compute minimum-image shift from local positions (orthorhombic).
+            // Triclinic-safe minimum-image shift (matches LAMMPS cell_shifts).
+            // invertBoxMatrix returns lower-triangular inverse, so upper triangle is 0.
             const double rawDx =
                     static_cast<double>(positions_[localJ][XX] - positions_[localI][XX]);
             const double rawDy =
@@ -829,12 +846,11 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
                     static_cast<double>(positions_[localJ][ZZ] - positions_[localI][ZZ]);
 
             IVec shift;
-            shift[XX] = static_cast<int>(
-                    std::round(-rawDx / static_cast<double>(box[XX][XX])));
-            shift[YY] = static_cast<int>(
-                    std::round(-rawDy / static_cast<double>(box[YY][YY])));
-            shift[ZZ] = static_cast<int>(
-                    std::round(-rawDz / static_cast<double>(box[ZZ][ZZ])));
+            shift[XX] = static_cast<int>(std::round(
+                    -(boxInv[XX][XX] * rawDx + boxInv[YY][XX] * rawDy + boxInv[ZZ][XX] * rawDz)));
+            shift[YY] = static_cast<int>(std::round(
+                    -(boxInv[YY][YY] * rawDy + boxInv[ZZ][YY] * rawDz)));
+            shift[ZZ] = static_cast<int>(std::round(-(boxInv[ZZ][ZZ] * rawDz)));
 
             backwardPairsMta_.push_back(localI);
             backwardPairsMta_.push_back(localJ);
@@ -872,7 +888,7 @@ void MetatomicForceProvider::distributeNonHomeForces(const double*        forces
 
     // For small systems, dense allreduce has lower latency than the
     // sparse exchange (gather counts + allgatherv).
-    constexpr int32_t sparseThreshold = 1000;
+    const int32_t sparseThreshold = data_->sparseThreshold;
 
     if (numTotalMta < sparseThreshold)
     {
@@ -997,16 +1013,19 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
     if (useNewtonNL)
     {
+        // Compute max cutoff across all NL requests (used by both ghost
+        // exchange and ring hop limit).
+        double maxCutoff = 0.0;
+        for (const auto& req : data_->nl_requests)
+        {
+            maxCutoff = std::max(maxCutoff, req->engine_cutoff("nm"));
+        }
+
         // Step 1: Exchange backward ghost atoms to fill the backward gap
         // in the DD halo.  Extends positions_, atomNumbers_, mtaToGlobalMta_
         // and numLocalMta_ with atoms from the backward PBC neighbor.
         {
             MetatomicTimer timer("exchangeBackwardGhosts", mpiComm_);
-            double maxCutoff = 0.0;
-            for (const auto& req : data_->nl_requests)
-            {
-                maxCutoff = std::max(maxCutoff, req->engine_cutoff("nm"));
-            }
             exchangeBackwardGhosts(inputs.dd_, inputs.box_, maxCutoff);
         }
 
@@ -1016,9 +1035,27 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
         // Step 2: Exchange backward-direction pairs.  Discovers pairs from
         // other ranks' pairlists that involve this rank's home atoms.
+        // Limit ring rounds to ceil(cutoff/minCellSize) when DD is available.
         {
             MetatomicTimer timer("exchangeBackwardPairs", mpiComm_);
-            exchangeBackwardPairs(inputs.box_);
+            int maxRounds = mpiComm_.size() - 1;
+            if (inputs.dd_ != nullptr && inputs.dd_->ndim > 0)
+            {
+                double minCellSize = 1e30;
+                for (int d = 0; d < inputs.dd_->ndim; d++)
+                {
+                    const int    dim = inputs.dd_->dim[d];
+                    const double cs  = static_cast<double>(inputs.box_[dim][dim])
+                                      / inputs.dd_->numCells[dim];
+                    minCellSize = std::min(minCellSize, cs);
+                }
+                if (minCellSize > 0.0)
+                {
+                    maxRounds = std::min(maxRounds,
+                                         static_cast<int>(std::ceil(maxCutoff / minCellSize)));
+                }
+            }
+            exchangeBackwardPairs(inputs.box_, maxRounds);
         }
 
         // Step 3: Temporarily extend pairlistMta_ with backward pairs

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -350,9 +350,9 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
     {
         auto v_energy_uq = normalize_variant(options_.params_.variantEnergyUq);
         bool has_uncertainty = false;
-        for (const auto& [key, val] : outputs)
+        for (const auto& entry : outputs)
         {
-            if (key.find("energy_uncertainty") == 0)
+            if (entry.key().find("energy_uncertainty") == 0)
             {
                 has_uncertainty = true;
                 break;
@@ -1397,22 +1397,24 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
         MetatomicTimer forwardTimer("forward", mpiComm_);
 
-        c10::impl::GenericDict dict_output(c10::AnyType::get(), c10::AnyType::get());
         metatensor_torch::TensorMap output_map;
+        c10::IValue                 ivalue_output;
         try
         {
             std::vector<metatomic_torch::System> systems;
             systems.push_back(system);
 
-            auto ivalue_output = data_->model.forward(
+            ivalue_output = data_->model.forward(
                     { systems, data_->evaluations_options, data_->check_consistency });
-            dict_output = ivalue_output.toGenericDict();
+            auto dict_output = ivalue_output.toGenericDict();
             output_map = dict_output.at("energy").toCustomClass<metatensor_torch::TensorMapHolder>();
         }
         catch (const std::exception& e)
         {
             GMX_THROW(APIError("[Metatomic] Model evaluation failed: " + std::string(e.what())));
         }
+        // Re-extract dict for uncertainty and NC access (auto type avoids GenericDict issues)
+        auto dict_output = ivalue_output.toGenericDict();
 
         forwardTimer.stop();
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -42,8 +42,10 @@
  * pair_metatomic).
  *
  * Common design points:
- *  - Forces: all-reduce on a global buffer because ForceWithVirial is not
- *    communicated by dd_move_f.  Only home atom forces are applied.
+ *  - Forces: home forces applied directly; non-home forces exchanged via
+ *    sparse indexed communication.  ForceWithVirial is not communicated
+ *    by dd_move_f, so we handle it ourselves.  Dense allreduce fallback
+ *    for small systems (N_total < 1000).
  *  - Ghost deduplication: periodic ghost images share the same model index
  *    but all GROMACS local indices are mapped via gmxLocalToMtaIdx_.
  *
@@ -59,7 +61,6 @@
 #include <cstdio>
 
 #include <algorithm>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -316,11 +317,6 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
     data_->evaluations_options->outputs.insert(energy_key, requested_output);
     data_->check_consistency = options_.params_.checkConsistency;
 
-    // Allocate global force buffer sized to total MTA atoms
-    const auto&   mtaIndices = options_.params_.mtaIndices_;
-    const int32_t n_total    = static_cast<int32_t>(mtaIndices.size());
-    globalForceBuffer_.resize(n_total, RVec({ 0.0, 0.0, 0.0 }));
-
     GMX_LOG(logger_.info)
             .asParagraph()
             .appendText("MetatomicForceProvider initialization complete.");
@@ -349,6 +345,7 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
     mtaToGlobalMta_.clear();
     atomNumbers_.clear();
     gmxLocalToMtaIdx_.clear();
+    globalMtaToLocalHome_.clear();
 
     if (mpiComm_.isParallel())
     {
@@ -502,6 +499,14 @@ void MetatomicForceProvider::gatherAtomNumbersIndices(const MDModulesAtomsRedist
             atomNumbers_[i]         = options_.params_.atoms_.atom[globalIdx].atomnumber;
             gmxLocalToMtaIdx_[localIndex] = i;
         }
+    }
+
+    // Build reverse map: global MTA index -> local home model index.
+    // Used by sparse force distribution to route incoming forces to home atoms.
+    globalMtaToLocalHome_.reserve(numHomeMta_);
+    for (int32_t i = 0; i < numHomeMta_; i++)
+    {
+        globalMtaToLocalHome_[mtaToGlobalMta_[i]] = i;
     }
 
     GMX_RELEASE_ASSERT(std::count(atomNumbers_.begin(), atomNumbers_.end(), 0) == 0,
@@ -715,56 +720,82 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
         return;
     }
 
-    const int32_t numTotalMta = static_cast<int32_t>(options_.params_.mtaIndices_.size());
-
-    // Step 1: Build global pair existence table via allreduce.
-    // pairTable[gI * numTotalMta + gJ] = 1 if any rank has pair (gI, gJ).
-    // After sumReduce, entries > 0 indicate pairs that exist somewhere.
-    std::vector<int> pairTable(numTotalMta * numTotalMta, 0);
     const int nMyPairs = static_cast<int>(pairlistMta_.size() / 2);
+
+    // Step 1: Pack local pairs as flat (globalI, globalJ) buffer.
+    std::vector<int> myPairsBuf(2 * nMyPairs);
     for (int k = 0; k < nMyPairs; k++)
     {
-        const int32_t gI = mtaToGlobalMta_[pairlistMta_[2 * k]];
-        const int32_t gJ = mtaToGlobalMta_[pairlistMta_[2 * k + 1]];
-        pairTable[gI * numTotalMta + gJ] = 1;
+        myPairsBuf[2 * k]     = mtaToGlobalMta_[pairlistMta_[2 * k]];
+        myPairsBuf[2 * k + 1] = mtaToGlobalMta_[pairlistMta_[2 * k + 1]];
     }
-    mpiComm_.sumReduce(static_cast<std::size_t>(numTotalMta * numTotalMta),
-                       pairTable.data());
 
-    // Step 2: Build set of my home atoms and existing canonical pairs.
+    // Step 2: Build set of my home atoms.
     std::unordered_set<int32_t> myHomeGlobalMta;
     for (int32_t i = 0; i < numHomeMta_; i++)
     {
         myHomeGlobalMta.insert(mtaToGlobalMta_[i]);
     }
 
-    // Canonical pair set {min(gI,gJ), max(gI,gJ)} to avoid half-list duplication.
-    std::set<std::pair<int32_t, int32_t>> existingCanonical;
+    // Step 3: Existing canonical pairs — O(1) lookup via hashed set.
+    struct PairHash
+    {
+        std::size_t operator()(const std::pair<int32_t, int32_t>& p) const
+        {
+            // Combine the two 32-bit ints into one 64-bit value for a perfect hash.
+            return std::hash<int64_t>()(static_cast<int64_t>(p.first) << 32
+                                        | static_cast<uint32_t>(p.second));
+        }
+    };
+    std::unordered_set<std::pair<int32_t, int32_t>, PairHash> existingCanonical;
+    existingCanonical.reserve(nMyPairs);
     for (int k = 0; k < nMyPairs; k++)
     {
-        const int32_t gI = mtaToGlobalMta_[pairlistMta_[2 * k]];
-        const int32_t gJ = mtaToGlobalMta_[pairlistMta_[2 * k + 1]];
+        const int32_t gI = myPairsBuf[2 * k];
+        const int32_t gJ = myPairsBuf[2 * k + 1];
         existingCanonical.insert({ std::min(gI, gJ), std::max(gI, gJ) });
     }
 
-    // Step 3: Build global MTA → local index mapping.
+    // Step 4: Global MTA → local index mapping.
     std::unordered_map<int32_t, int32_t> globalToLocal;
+    globalToLocal.reserve(numLocalMta_);
     for (int32_t i = 0; i < numLocalMta_; i++)
     {
         globalToLocal[mtaToGlobalMta_[i]] = i;
     }
 
-    // Step 4: Find pairs I need but don't have.
-    for (int32_t gI = 0; gI < numTotalMta; gI++)
-    {
-        for (int32_t gJ = 0; gJ < numTotalMta; gJ++)
-        {
-            if (pairTable[gI * numTotalMta + gJ] == 0)
-            {
-                continue;
-            }
+    // Step 5: Ring exchange — P-1 rounds of MPI_Sendrecv.
+    // Each round: send our pairs to rank+1, receive from rank-1.
+    // Scan received pairs for those involving our home atoms.
+    const int numRanks = mpiComm_.size();
+    const int myRank   = mpiComm_.rank();
+    const int sendTo   = (myRank + 1) % numRanks;
+    const int recvFrom = (myRank - 1 + numRanks) % numRanks;
 
-            // Pair must involve one of my home atoms.
+    std::vector<int> sendBuf = myPairsBuf;
+    std::vector<int> recvBuf;
+
+    for (int round = 0; round < numRanks - 1; round++)
+    {
+        // Exchange counts first so receiver knows buffer size.
+        int sendCount = static_cast<int>(sendBuf.size());
+        int recvCount = 0;
+        MPI_Sendrecv(&sendCount, 1, MPI_INT, sendTo, 0,
+                     &recvCount, 1, MPI_INT, recvFrom, 0,
+                     mpiComm_.comm(), MPI_STATUS_IGNORE);
+
+        recvBuf.resize(recvCount);
+        MPI_Sendrecv(sendBuf.data(), sendCount, MPI_INT, sendTo, 1,
+                     recvBuf.data(), recvCount, MPI_INT, recvFrom, 1,
+                     mpiComm_.comm(), MPI_STATUS_IGNORE);
+
+        // Scan received pairs for those involving our home atoms.
+        const int nRecvPairs = recvCount / 2;
+        for (int k = 0; k < nRecvPairs; k++)
+        {
+            const int32_t gI = recvBuf[2 * k];
+            const int32_t gJ = recvBuf[2 * k + 1];
+
             const bool iIsMyHome = myHomeGlobalMta.count(gI) > 0;
             const bool jIsMyHome = myHomeGlobalMta.count(gJ) > 0;
             if (!iIsMyHome && !jIsMyHome)
@@ -772,7 +803,6 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
                 continue;
             }
 
-            // Skip if I already have this pair (in either direction).
             auto canonical = std::make_pair(std::min(gI, gJ), std::max(gI, gJ));
             if (existingCanonical.count(canonical) > 0)
             {
@@ -811,6 +841,9 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
             backwardShiftsMta_.push_back(shift);
             existingCanonical.insert(canonical);
         }
+
+        // Forward received buffer for the next round.
+        sendBuf.swap(recvBuf);
     }
 
     if (data_->debugEnabled)
@@ -821,7 +854,7 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
         if (fp)
         {
             std::fprintf(fp,
-                         "exchangeBackwardPairs: added %zu pairs "
+                         "exchangeBackwardPairs(ring): added %zu pairs "
                          "(pairlist=%d, total=%zu)\n",
                          backwardPairsMta_.size() / 2,
                          nMyPairs,
@@ -832,11 +865,113 @@ void MetatomicForceProvider::exchangeBackwardPairs(const matrix box)
 }
 
 
+void MetatomicForceProvider::distributeNonHomeForces(const double*        forces,
+                                                     ForceProviderOutput* outputs)
+{
+    const int32_t numTotalMta = static_cast<int32_t>(options_.params_.mtaIndices_.size());
+
+    // For small systems, dense allreduce has lower latency than the
+    // sparse exchange (gather counts + allgatherv).
+    constexpr int32_t sparseThreshold = 1000;
+
+    if (numTotalMta < sparseThreshold)
+    {
+        // Dense fallback: allocate N_total buffer, scatter, allreduce, readback.
+        std::vector<double> denseForces(3 * numTotalMta, 0.0);
+        for (int32_t i = 0; i < numLocalMta_; i++)
+        {
+            int32_t g = mtaToGlobalMta_[i];
+            denseForces[3 * g]     = forces[3 * i];
+            denseForces[3 * g + 1] = forces[3 * i + 1];
+            denseForces[3 * g + 2] = forces[3 * i + 2];
+        }
+        mpiComm_.sumReduce(static_cast<std::size_t>(3 * numTotalMta), denseForces.data());
+
+        for (int32_t i = 0; i < numHomeMta_; i++)
+        {
+            int32_t gmxIdx = mtaToGmxLocal_[i];
+            int32_t g      = mtaToGlobalMta_[i];
+            outputs->forceWithVirial_.force_[gmxIdx][0] += static_cast<real>(denseForces[3 * g]);
+            outputs->forceWithVirial_.force_[gmxIdx][1] += static_cast<real>(denseForces[3 * g + 1]);
+            outputs->forceWithVirial_.force_[gmxIdx][2] += static_cast<real>(denseForces[3 * g + 2]);
+        }
+        return;
+    }
+
+    // Sparse path: apply home forces directly, exchange only non-home forces.
+
+    // Step 1: Apply home atom forces directly (no communication needed).
+    for (int32_t i = 0; i < numHomeMta_; i++)
+    {
+        int32_t gmxIdx = mtaToGmxLocal_[i];
+        outputs->forceWithVirial_.force_[gmxIdx][0] += static_cast<real>(forces[3 * i]);
+        outputs->forceWithVirial_.force_[gmxIdx][1] += static_cast<real>(forces[3 * i + 1]);
+        outputs->forceWithVirial_.force_[gmxIdx][2] += static_cast<real>(forces[3 * i + 2]);
+    }
+
+    // Step 2: Pack non-home forces as sparse tuples (globalMtaIdx, fx, fy, fz).
+    // Each tuple is 4 doubles: [globalMtaIdx_as_double, fx, fy, fz].
+    const int32_t numNonHome = numLocalMta_ - numHomeMta_;
+    std::vector<double> sendBuf(4 * numNonHome);
+    for (int32_t i = numHomeMta_; i < numLocalMta_; i++)
+    {
+        int32_t k = i - numHomeMta_;
+        sendBuf[4 * k]     = static_cast<double>(mtaToGlobalMta_[i]);
+        sendBuf[4 * k + 1] = forces[3 * i];
+        sendBuf[4 * k + 2] = forces[3 * i + 1];
+        sendBuf[4 * k + 3] = forces[3 * i + 2];
+    }
+
+    // Step 3: Exchange counts via allreduce on a P-element array.
+    const int numRanks = mpiComm_.size();
+    std::vector<int> counts(numRanks, 0);
+    counts[mpiComm_.rank()] = numNonHome;
+    mpiComm_.sumReduce(ArrayRef<int>(counts));
+
+    // Step 4: Allgatherv via Gatherv + Bcast (thread-MPI compatible).
+    int totalNonHome = 0;
+    std::vector<int> displs(numRanks);
+    for (int r = 0; r < numRanks; r++)
+    {
+        displs[r] = totalNonHome;
+        totalNonHome += counts[r];
+    }
+
+    // Scale counts/displs to doubles (4 per tuple)
+    std::vector<int> dcounts(numRanks), ddispls(numRanks);
+    for (int r = 0; r < numRanks; r++)
+    {
+        dcounts[r] = 4 * counts[r];
+        ddispls[r] = 4 * displs[r];
+    }
+
+    std::vector<double> recvBuf(4 * totalNonHome);
+    MPI_Gatherv(sendBuf.data(), 4 * numNonHome, MPI_DOUBLE,
+                recvBuf.data(), dcounts.data(), ddispls.data(), MPI_DOUBLE,
+                mpiComm_.mainRank(), mpiComm_.comm());
+    MPI_Bcast(recvBuf.data(), 4 * totalNonHome, MPI_DOUBLE,
+              mpiComm_.mainRank(), mpiComm_.comm());
+
+    // Step 5: Scan received tuples for forces destined for our home atoms.
+    for (int t = 0; t < totalNonHome; t++)
+    {
+        int32_t globalMtaIdx = static_cast<int32_t>(recvBuf[4 * t]);
+        auto    it           = globalMtaToLocalHome_.find(globalMtaIdx);
+        if (it != globalMtaToLocalHome_.end())
+        {
+            int32_t localHomeIdx = it->second;
+            int32_t gmxIdx       = mtaToGmxLocal_[localHomeIdx];
+            outputs->forceWithVirial_.force_[gmxIdx][0] += static_cast<real>(recvBuf[4 * t + 1]);
+            outputs->forceWithVirial_.force_[gmxIdx][1] += static_cast<real>(recvBuf[4 * t + 2]);
+            outputs->forceWithVirial_.force_[gmxIdx][2] += static_cast<real>(recvBuf[4 * t + 3]);
+        }
+    }
+}
+
+
 void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, ForceProviderOutput* outputs)
 {
     MetatomicTimer totalTimer("calculateForces", mpiComm_);
-
-    const int32_t numTotalMta = static_cast<int32_t>(options_.params_.mtaIndices_.size());
 
     // Fill local positions (no MPI communication)
     {
@@ -1164,41 +1299,16 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         toCPUTimer.stop();
     }
 
-    // Force distribution via all-reduce.
-    // backward() produces forces on ALL local atoms (home + halo).  Since
-    // ForceWithVirial forces are NOT communicated by dd_move_f (which only
-    // handles ForceWithShiftForces), we must all-reduce ourselves.  Each rank
-    // scatters its local forces into a global buffer indexed by global MTA
-    // index.  After all-reduce, each rank reads back only its home atoms.
+    // Force distribution: home forces applied directly, non-home forces
+    // exchanged via sparse indexed communication (or dense fallback for
+    // small systems). ForceWithVirial is NOT communicated by dd_move_f.
     MetatomicTimer forceScatterTimer("forceScatter", mpiComm_);
 
-    auto forceAccessor = forceTensor.accessor<double, 2>();
+    const double* forceData = forceTensor.data_ptr<double>();
 
     if (mpiComm_.isParallel())
     {
-        globalForceBuffer_.resize(numTotalMta);
-        std::fill(globalForceBuffer_.begin(), globalForceBuffer_.end(), RVec({ 0.0, 0.0, 0.0 }));
-
-        // Scatter local forces into the global buffer.
-        for (int32_t i = 0; i < numLocalMta_; i++)
-        {
-            int32_t globalMtaIdx                = mtaToGlobalMta_[i];
-            globalForceBuffer_[globalMtaIdx][0] = static_cast<real>(forceAccessor[i][0]);
-            globalForceBuffer_[globalMtaIdx][1] = static_cast<real>(forceAccessor[i][1]);
-            globalForceBuffer_[globalMtaIdx][2] = static_cast<real>(forceAccessor[i][2]);
-        }
-
-        mpiComm_.sumReduce(3 * numTotalMta, globalForceBuffer_.data()->as_vec());
-
-        // Apply forces only to home MTA atoms from the reduced buffer
-        for (int32_t i = 0; i < numHomeMta_; i++)
-        {
-            int32_t gmxIdx       = mtaToGmxLocal_[i];
-            int32_t globalMtaIdx = mtaToGlobalMta_[i];
-            outputs->forceWithVirial_.force_[gmxIdx][0] += globalForceBuffer_[globalMtaIdx][0];
-            outputs->forceWithVirial_.force_[gmxIdx][1] += globalForceBuffer_[globalMtaIdx][1];
-            outputs->forceWithVirial_.force_[gmxIdx][2] += globalForceBuffer_[globalMtaIdx][2];
-        }
+        distributeNonHomeForces(forceData, outputs);
     }
     else
     {
@@ -1206,9 +1316,9 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         for (int32_t i = 0; i < numLocalMta_; i++)
         {
             int32_t gmxIdx = mtaToGmxLocal_[i];
-            outputs->forceWithVirial_.force_[gmxIdx][0] += static_cast<real>(forceAccessor[i][0]);
-            outputs->forceWithVirial_.force_[gmxIdx][1] += static_cast<real>(forceAccessor[i][1]);
-            outputs->forceWithVirial_.force_[gmxIdx][2] += static_cast<real>(forceAccessor[i][2]);
+            outputs->forceWithVirial_.force_[gmxIdx][0] += static_cast<real>(forceData[3 * i]);
+            outputs->forceWithVirial_.force_[gmxIdx][1] += static_cast<real>(forceData[3 * i + 1]);
+            outputs->forceWithVirial_.force_[gmxIdx][2] += static_cast<real>(forceData[3 * i + 2]);
         }
     }
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -155,6 +155,22 @@ struct MetatomicData
 
     //! Sparse/dense force exchange threshold (atom count). Env: GMX_METATOMIC_SPARSE_THRESHOLD.
     int32_t sparseThreshold = 1000;
+
+    //! Energy uncertainty output key (empty if disabled or model lacks it).
+    std::string energy_uq_key;
+    //! Requested uncertainty output (nullptr if disabled).
+    metatomic_torch::ModelOutput uncertainty_output;
+    //! Uncertainty threshold in kJ/mol. Atoms above this trigger a warning.
+    double uncertaintyThreshold = 0.0;
+
+    //! Non-conservative mode: forces/stress predicted directly, no backward pass.
+    bool nonConservative = false;
+    //! Output keys for non-conservative forces and stress.
+    std::string nc_forces_key;
+    std::string nc_stress_key;
+    //! Requested outputs for non-conservative mode.
+    metatomic_torch::ModelOutput nc_forces_output;
+    metatomic_torch::ModelOutput nc_stress_output;
 };
 
 MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
@@ -328,6 +344,121 @@ MetatomicForceProvider::MetatomicForceProvider(const MetatomicOptions& options,
 
     data_->evaluations_options->outputs.insert(energy_key, requested_output);
     data_->check_consistency = options_.params_.checkConsistency;
+
+    // Uncertainty checking: auto-detect energy_uncertainty output from model
+    if (options_.params_.uncertaintyThreshold != "off")
+    {
+        auto v_energy_uq = normalize_variant(options_.params_.variantEnergyUq);
+        bool has_uncertainty = false;
+        for (const auto& [key, val] : outputs)
+        {
+            if (key.find("energy_uncertainty") == 0)
+            {
+                has_uncertainty = true;
+                break;
+            }
+        }
+
+        if (has_uncertainty)
+        {
+            data_->energy_uq_key = pick_output("energy_uncertainty", outputs, v_energy_uq);
+            auto uq_cap = outputs.at(data_->energy_uq_key);
+
+            if (uq_cap->per_atom)
+            {
+                data_->uncertainty_output =
+                        torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+                data_->uncertainty_output->set_quantity("energy");
+                data_->uncertainty_output->set_unit("kJ/mol");
+                data_->uncertainty_output->per_atom = true;
+
+                if (options_.params_.uncertaintyThreshold == "auto")
+                {
+                    // Default: 100 meV/atom converted to kJ/mol
+                    data_->uncertaintyThreshold =
+                            0.1 * metatomic_torch::unit_conversion_factor("energy", "eV", "kJ/mol");
+                }
+                else
+                {
+                    data_->uncertaintyThreshold =
+                            std::stod(options_.params_.uncertaintyThreshold);
+                }
+
+                data_->evaluations_options->outputs.insert(
+                        data_->energy_uq_key, data_->uncertainty_output);
+
+                GMX_LOG(logger_.info)
+                        .asParagraph()
+                        .appendTextFormatted(
+                                "Metatomic: found '%s' output, will check for atoms with "
+                                "high uncertainty (threshold: %.4f kJ/mol)",
+                                data_->energy_uq_key.c_str(),
+                                data_->uncertaintyThreshold);
+            }
+        }
+    }
+
+    // Non-conservative mode: model predicts forces/stress directly
+    data_->nonConservative = options_.params_.nonConservative;
+    if (data_->nonConservative)
+    {
+        auto v_nc_forces = normalize_variant(options_.params_.variantNcForces);
+        auto v_nc_stress = normalize_variant(options_.params_.variantNcStress);
+
+        // Both variant overrides must match if both are set (LAMMPS convention)
+        if (v_nc_forces.has_value() && v_nc_stress.has_value()
+            && v_nc_forces.value() != v_nc_stress.value())
+        {
+            GMX_THROW(APIError(
+                    "if both 'variant-nc-forces' and 'variant-nc-stress' are present, "
+                    "they must have the same value"));
+        }
+
+        data_->nc_forces_key = pick_output("non_conservative_forces", outputs, v_nc_forces);
+        if (!outputs.contains(data_->nc_forces_key))
+        {
+            GMX_THROW(APIError(formatString(
+                    "The model does not provide '%s' output, "
+                    "we can not enable non-conservative simulations",
+                    data_->nc_forces_key.c_str())));
+        }
+        auto nc_forces_cap = outputs.at(data_->nc_forces_key);
+        if (!nc_forces_cap->per_atom)
+        {
+            GMX_THROW(APIError(formatString(
+                    "The model's '%s' output can not produce per-atom output, "
+                    "we can not enable non-conservative simulations",
+                    data_->nc_forces_key.c_str())));
+        }
+
+        data_->nc_forces_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+        data_->nc_forces_output->set_quantity("force");
+        data_->nc_forces_output->set_unit("kJ/mol/nm");
+        data_->nc_forces_output->per_atom = true;
+
+        data_->evaluations_options->outputs.insert(
+                data_->nc_forces_key, data_->nc_forces_output);
+
+        data_->nc_stress_key = pick_output("non_conservative_stress", outputs, v_nc_stress);
+        if (outputs.contains(data_->nc_stress_key))
+        {
+            data_->nc_stress_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+            data_->nc_stress_output->set_quantity("stress");
+            data_->nc_stress_output->set_unit("kJ/mol/nm^3");
+            data_->nc_stress_output->per_atom = false;
+
+            data_->evaluations_options->outputs.insert(
+                    data_->nc_stress_key, data_->nc_stress_output);
+        }
+
+        GMX_LOG(logger_.info)
+                .asParagraph()
+                .appendTextFormatted(
+                        "Metatomic: non-conservative mode enabled. Forces from '%s', "
+                        "stress from '%s'",
+                        data_->nc_forces_key.c_str(),
+                        data_->nc_stress_key.c_str());
+    }
 
     GMX_LOG(logger_.info)
             .asParagraph()
@@ -1087,13 +1218,14 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
         auto torch_positions = torch::from_blob(positions_.data()->as_vec(), { static_cast<int64_t>(numLocalMta_), 3 }, cpu_blob_options)
                                        .to(data_->device, data_->dtype)
-                                       .set_requires_grad(true);
+                                       .set_requires_grad(!data_->nonConservative);
 
         auto torch_cell =
                 torch::from_blob(&box_, { 3, 3 }, cpu_blob_options).to(data_->device, data_->dtype);
 
         auto strain = torch::eye(
-                3, torch::TensorOptions().dtype(data_->dtype).device(data_->device).requires_grad(true));
+                3, torch::TensorOptions().dtype(data_->dtype).device(data_->device)
+                           .requires_grad(!data_->nonConservative));
 
         auto strained_cell      = torch::matmul(torch_cell, strain);
         auto strained_positions = torch::matmul(torch_positions, strain);
@@ -1265,6 +1397,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
         MetatomicTimer forwardTimer("forward", mpiComm_);
 
+        c10::Dict<c10::IValue, c10::IValue> dict_output;
         metatensor_torch::TensorMap output_map;
         try
         {
@@ -1273,7 +1406,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
             auto ivalue_output = data_->model.forward(
                     { systems, data_->evaluations_options, data_->check_consistency });
-            auto dict_output = ivalue_output.toGenericDict();
+            dict_output = ivalue_output.toGenericDict();
             output_map = dict_output.at("energy").toCustomClass<metatensor_torch::TensorMapHolder>();
         }
         catch (const std::exception& e)
@@ -1282,6 +1415,31 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
         }
 
         forwardTimer.stop();
+
+        // Check uncertainty if the model provides it
+        if (data_->uncertainty_output != nullptr
+            && dict_output.contains(data_->energy_uq_key))
+        {
+            auto uq_map = dict_output.at(data_->energy_uq_key)
+                                  .toCustomClass<metatensor_torch::TensorMapHolder>();
+            auto uq_block = metatensor_torch::TensorMapHolder::block_by_id(uq_map, 0);
+            auto uq_values = uq_block->values().reshape({ -1 });
+            auto atoms_above = uq_values > data_->uncertaintyThreshold;
+
+            if (torch::any(atoms_above).to(torch::kCPU).item<bool>())
+            {
+                int64_t nAbove = torch::sum(atoms_above.to(torch::kInt64))
+                                         .to(torch::kCPU).item<int64_t>();
+                GMX_LOG(logger_.warning)
+                        .asParagraph()
+                        .appendTextFormatted(
+                                "Metatomic: uncertainty on atomic energies for %ld atoms "
+                                "is larger than the threshold of %.4f kJ/mol. "
+                                "Consider retraining the model.",
+                                static_cast<long>(nAbove),
+                                data_->uncertaintyThreshold);
+            }
+        }
 
         auto energy_block  = metatensor_torch::TensorMapHolder::block_by_id(output_map, 0);
         auto energy_tensor = energy_block->values();
@@ -1316,34 +1474,97 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
             }
         }
 
-        MetatomicTimer backwardTimer("backward", mpiComm_);
+        if (data_->nonConservative)
+        {
+            // Non-conservative: extract forces directly from model output
+            MetatomicTimer ncTimer("ncExtract", mpiComm_);
 
-        torch_positions.mutable_grad() = torch::Tensor();
-        strain.mutable_grad()          = torch::Tensor();
+            auto forces_map =
+                    dict_output.at(data_->nc_forces_key)
+                            .toCustomClass<metatensor_torch::TensorMapHolder>();
+            auto forces_block =
+                    metatensor_torch::TensorMapHolder::block_by_id(forces_map, 0);
+            forceTensor = forces_block->values().squeeze(-1)
+                                  .to(torch::kCPU).to(torch::kFloat64);
 
-        // Backpropagate through all returned per-atom energies.
-        // In parallel, output is restricted to home atoms via selected_atoms.
-        // Forces propagate to ALL local atoms (home + halo) via the NL autograd.
-        energy_tensor.backward(-torch::ones_like(energy_tensor));
+            // Virial from stress if available
+            if (data_->nc_stress_output != nullptr)
+            {
+                auto stress_map =
+                        dict_output.at(data_->nc_stress_key)
+                                .toCustomClass<metatensor_torch::TensorMapHolder>();
+                auto stress_block =
+                        metatensor_torch::TensorMapHolder::block_by_id(stress_map, 0);
+                auto stress_tensor = stress_block->values().squeeze(0).squeeze(-1);
 
-        backwardTimer.stop();
+                // Compute volume from box
+                double volume = inputs.box_[XX][XX]
+                                * (inputs.box_[YY][YY] * inputs.box_[ZZ][ZZ]
+                                   - inputs.box_[YY][ZZ] * inputs.box_[ZZ][YY])
+                                - inputs.box_[XX][YY]
+                                          * (inputs.box_[YY][XX] * inputs.box_[ZZ][ZZ]
+                                             - inputs.box_[YY][ZZ] * inputs.box_[ZZ][XX])
+                                + inputs.box_[XX][ZZ]
+                                          * (inputs.box_[YY][XX] * inputs.box_[ZZ][YY]
+                                             - inputs.box_[YY][YY] * inputs.box_[ZZ][XX]);
 
-        MetatomicTimer toCPUTimer("toCPU", mpiComm_);
+                virialTensor = (-stress_tensor * volume)
+                                       .to(torch::kCPU).to(torch::kFloat64);
+            }
+            else
+            {
+                virialTensor = torch::zeros({ 3, 3 }, torch::kFloat64);
+            }
 
-        forceTensor  = torch_positions.grad().to(torch::kCPU).to(torch::kFloat64);
-        virialTensor = strain.grad().to(torch::kCPU).to(torch::kFloat64);
+            ncTimer.stop();
+        }
+        else
+        {
+            // Conservative: backward pass for forces and virial via autograd
+            MetatomicTimer backwardTimer("backward", mpiComm_);
 
-        toCPUTimer.stop();
+            torch_positions.mutable_grad() = torch::Tensor();
+            strain.mutable_grad()          = torch::Tensor();
+
+            // Backpropagate through all returned per-atom energies.
+            // In parallel, output is restricted to home atoms via selected_atoms.
+            // Forces propagate to ALL local atoms (home + halo) via the NL autograd.
+            energy_tensor.backward(-torch::ones_like(energy_tensor));
+
+            backwardTimer.stop();
+
+            MetatomicTimer toCPUTimer("toCPU", mpiComm_);
+
+            forceTensor  = torch_positions.grad().to(torch::kCPU).to(torch::kFloat64);
+            virialTensor = strain.grad().to(torch::kCPU).to(torch::kFloat64);
+
+            toCPUTimer.stop();
+        }
     }
 
     // Force distribution: home forces applied directly, non-home forces
     // exchanged via sparse indexed communication (or dense fallback for
     // small systems). ForceWithVirial is NOT communicated by dd_move_f.
+    // In non-conservative mode, the model returns forces for home atoms
+    // only (via selected_atoms), so we skip halo force exchange.
     MetatomicTimer forceScatterTimer("forceScatter", mpiComm_);
 
     const double* forceData = forceTensor.data_ptr<double>();
+    const int32_t nForceAtoms = static_cast<int32_t>(forceTensor.size(0));
 
-    if (mpiComm_.isParallel())
+    if (data_->nonConservative)
+    {
+        // NC mode: forces are for home atoms only (or all atoms in serial).
+        // Apply directly, no halo exchange needed.
+        for (int32_t i = 0; i < nForceAtoms; i++)
+        {
+            int32_t gmxIdx = mtaToGmxLocal_[i];
+            outputs->forceWithVirial_.force_[gmxIdx][0] += static_cast<real>(forceData[3 * i]);
+            outputs->forceWithVirial_.force_[gmxIdx][1] += static_cast<real>(forceData[3 * i + 1]);
+            outputs->forceWithVirial_.force_[gmxIdx][2] += static_cast<real>(forceData[3 * i + 2]);
+        }
+    }
+    else if (mpiComm_.isParallel())
     {
         distributeNonHomeForces(forceData, outputs);
     }

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.cpp
@@ -1397,7 +1397,7 @@ void MetatomicForceProvider::calculateForces(const ForceProviderInput& inputs, F
 
         MetatomicTimer forwardTimer("forward", mpiComm_);
 
-        c10::Dict<c10::IValue, c10::IValue> dict_output;
+        c10::impl::GenericDict dict_output(c10::AnyType::get(), c10::AnyType::get());
         metatensor_torch::TensorMap output_map;
         try
         {

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
@@ -131,9 +131,11 @@ private:
      * Must be called after exchangeBackwardGhosts() (so all atom positions
      * are available) and before the NL building loop.
      *
-     * \param[in] box  Current simulation box.
+     * \param[in] box        Current simulation box.
+     * \param[in] maxRounds  Maximum number of ring exchange rounds (capped by
+     *                       ceil(cutoff/minCellSize) when DD info is available).
      */
-    void exchangeBackwardPairs(const matrix box);
+    void exchangeBackwardPairs(const matrix box, int maxRounds);
 
     /*! \brief Exchange backward ghost MTA atoms via DD to fill the backward gap.
      *

--- a/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_forceprovider.h
@@ -82,8 +82,10 @@ class MpiComm;
  * be resolved.
  *
  * **Forces**: backward() produces forces on all local atoms (home + halo).
- * Since ForceWithVirial is not communicated by dd_move_f, we scatter forces
- * into a global buffer and MPI all-reduce, then apply only to home atoms.
+ * Since ForceWithVirial is not communicated by dd_move_f, home forces are
+ * applied directly and non-home (halo) forces are exchanged via sparse
+ * indexed communication (allgatherv pattern). Falls back to dense allreduce
+ * for small systems (N_total_mta < 1000).
  *
  * **Shift convention**: GROMACS shifts atom I (first):
  * d = x[I]+shift - x[J]. Metatensor convention: r_ij = x[J] + cell_shift*box
@@ -115,14 +117,16 @@ private:
     //! Gather atom positions for MTA input (local only, no MPI).
     void gatherAtomPositions(ArrayRef<const RVec> positions);
 
-    /*! \brief Exchange backward-direction pairs via the GROMACS pairlist.
+    /*! \brief Exchange backward-direction pairs via ring-based MPI_Sendrecv.
      *
      * In GROMACS DD, the excluded pairlist assigns each pair to exactly one
      * rank (the rank whose home atom is the i-atom). For newton mode, each
      * rank needs ALL pairs involving its home atoms, including those assigned
      * to other ranks. This method discovers those missing pairs by
-     * allreducing a global pair existence table, then adds them to
-     * backwardPairsMta_ with shifts recomputed from local positions.
+     * circulating packed (globalI, globalJ) pair buffers in P-1 ring rounds,
+     * then adds them to backwardPairsMta_ with shifts recomputed from local
+     * positions. Complexity: O(total_pairs) communication, O(max_pairs/rank)
+     * memory — replaces the previous O(N²) pair table allreduce.
      *
      * Must be called after exchangeBackwardGhosts() (so all atom positions
      * are available) and before the NL building loop.
@@ -158,6 +162,12 @@ private:
      */
     int32_t exchangeBackwardGhosts(const gmx_domdec_t* dd, const matrix box, double cutoff);
 
+    //! Distribute non-home forces via sparse indexed exchange (allgatherv pattern).
+    //! Home forces are applied directly; only halo forces are communicated.
+    //! \param[in] forces   Flat force array [numLocalMta_ * 3], row-major (fx,fy,fz).
+    //! \param[out] outputs Force provider output to accumulate into.
+    void distributeNonHomeForces(const double* forces, ForceProviderOutput* outputs);
+
     const MetatomicOptions& options_;
     const MDLogger&         logger_;
     const MpiComm&          mpiComm_;
@@ -186,10 +196,10 @@ private:
     //! Initialized to -1 for non-MTA atoms.
     std::vector<int32_t> gmxLocalToMtaIdx_;
 
-    //! Global force buffer [N_total_mta] for MPI all-reduce of forces.
-    //! Each rank scatters its local forces here, all-reduce sums them,
-    //! then home forces are read back.
-    std::vector<RVec> globalForceBuffer_;
+    //! Maps global MTA index -> local home model index (only home atoms).
+    //! Built in gatherAtomNumbersIndices(), used by distributeNonHomeForces()
+    //! to identify incoming forces destined for this rank's home atoms.
+    std::unordered_map<int32_t, int32_t> globalMtaToLocalHome_;
 
     //! Pairlist in MTA model indices, flat [i0,j0, i1,j1, ...].
     //! Built from GROMACS excludedPairlist_ with negated cell shifts.

--- a/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_mdmodule.cpp
@@ -239,16 +239,6 @@ public:
                     GMX_THROW(InconsistentInputError("Metatomic model cutoff is 0.0 or invalid."));
                 }
             }
-            // TODO: For multi-layer GNN models (MACE, NequIP, etc.) the
-            // interaction_range should be n_layers * cutoff so that domain decomposition halos
-            // are deep enough for message-passing.  Many models currently
-            // report interaction_range == cutoff, which makes domain decomposition give wrong
-            // energies because halo atoms lack complete neighborhoods.
-            // Unlike LAMMPS (which adds a ~2 Å neighbor skin on top of the
-            // cutoff), GROMACS caps the domain decomposition range at rlist, so we cannot add
-            // extra range here.  The model must report the correct
-            // interaction_range, or the user must increase rcoulomb/rvdw in
-            // the .mdp so that rlist >= interaction_range.
             ranges->addRange(max_cutoff);
         };
         // Register the callback

--- a/src/gromacs/applied_forces/metatomic/metatomic_options.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_options.cpp
@@ -78,6 +78,11 @@ static const std::string EXTENSIONS_DIRECTORY_TAG = "extensions";
 static const std::string CHECK_CONSISTENCY_TAG    = "check-consistency";
 static const std::string DEVICE_TAG               = "device";
 static const std::string VARIANT_TAG              = "variant";
+static const std::string UNCERTAINTY_THRESHOLD_TAG = "uncertainty-threshold";
+static const std::string VARIANT_ENERGY_UQ_TAG     = "variant-energy-uq";
+static const std::string NON_CONSERVATIVE_TAG      = "non-conservative";
+static const std::string VARIANT_NC_FORCES_TAG     = "variant-nc-forces";
+static const std::string VARIANT_NC_STRESS_TAG     = "variant-nc-stress";
 
 namespace
 {
@@ -141,6 +146,16 @@ void MetatomicOptions::initMdpTransform(IKeyValueTreeTransformRules* rules)
     addMdpTransformFromString<std::string>(rules, stringIdentityTransform, METATOMIC_MODULE_NAME, DEVICE_TAG);
     addMdpTransformFromString<std::string>(
             rules, stringIdentityTransform, METATOMIC_MODULE_NAME, VARIANT_TAG);
+    addMdpTransformFromString<std::string>(
+            rules, stringIdentityTransform, METATOMIC_MODULE_NAME, UNCERTAINTY_THRESHOLD_TAG);
+    addMdpTransformFromString<std::string>(
+            rules, stringIdentityTransform, METATOMIC_MODULE_NAME, VARIANT_ENERGY_UQ_TAG);
+    addMdpTransformFromString<bool>(
+            rules, &fromStdString<bool>, METATOMIC_MODULE_NAME, NON_CONSERVATIVE_TAG);
+    addMdpTransformFromString<std::string>(
+            rules, stringIdentityTransform, METATOMIC_MODULE_NAME, VARIANT_NC_FORCES_TAG);
+    addMdpTransformFromString<std::string>(
+            rules, stringIdentityTransform, METATOMIC_MODULE_NAME, VARIANT_NC_STRESS_TAG);
 }
 
 void MetatomicOptions::initMdpOptions(IOptionsContainerWithSections* options)
@@ -154,6 +169,11 @@ void MetatomicOptions::initMdpOptions(IOptionsContainerWithSections* options)
     section.addOption(StringOption(DEVICE_TAG.c_str()).store(&params_.device));
     section.addOption(BooleanOption(CHECK_CONSISTENCY_TAG.c_str()).store(&params_.checkConsistency));
     section.addOption(StringOption(VARIANT_TAG.c_str()).store(&params_.variant));
+    section.addOption(StringOption(UNCERTAINTY_THRESHOLD_TAG.c_str()).store(&params_.uncertaintyThreshold));
+    section.addOption(StringOption(VARIANT_ENERGY_UQ_TAG.c_str()).store(&params_.variantEnergyUq));
+    section.addOption(BooleanOption(NON_CONSERVATIVE_TAG.c_str()).store(&params_.nonConservative));
+    section.addOption(StringOption(VARIANT_NC_FORCES_TAG.c_str()).store(&params_.variantNcForces));
+    section.addOption(StringOption(VARIANT_NC_STRESS_TAG.c_str()).store(&params_.variantNcStress));
 }
 
 void MetatomicOptions::buildMdpOutput(KeyValueTreeObjectBuilder* builder) const
@@ -179,6 +199,16 @@ void MetatomicOptions::buildMdpOutput(KeyValueTreeObjectBuilder* builder) const
         addMdpOutputValue<bool>(
                 builder, METATOMIC_MODULE_NAME, CHECK_CONSISTENCY_TAG, params_.checkConsistency);
         addMdpOutputValue<std::string>(builder, METATOMIC_MODULE_NAME, VARIANT_TAG, params_.variant);
+        addMdpOutputValue<std::string>(
+                builder, METATOMIC_MODULE_NAME, UNCERTAINTY_THRESHOLD_TAG, params_.uncertaintyThreshold);
+        addMdpOutputValue<std::string>(
+                builder, METATOMIC_MODULE_NAME, VARIANT_ENERGY_UQ_TAG, params_.variantEnergyUq);
+        addMdpOutputValue<bool>(
+                builder, METATOMIC_MODULE_NAME, NON_CONSERVATIVE_TAG, params_.nonConservative);
+        addMdpOutputValue<std::string>(
+                builder, METATOMIC_MODULE_NAME, VARIANT_NC_FORCES_TAG, params_.variantNcForces);
+        addMdpOutputValue<std::string>(
+                builder, METATOMIC_MODULE_NAME, VARIANT_NC_STRESS_TAG, params_.variantNcStress);
     }
 }
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_options.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_options.h
@@ -85,6 +85,17 @@ struct MetatomicParameters
     //! predictions
     std::string variant;
 
+    //! Uncertainty threshold: "auto" (100 meV/atom), "off", or a number in kJ/mol
+    std::string uncertaintyThreshold = "auto";
+    //! Variant override for energy_uncertainty output
+    std::string variantEnergyUq;
+
+    //! Enable non-conservative mode (forces/stress predicted directly, no backward pass)
+    bool nonConservative = false;
+    //! Variant overrides for non-conservative outputs
+    std::string variantNcForces;
+    std::string variantNcStress;
+
     // TODO: how should we translate atomic types?
 
     //! stores atom group name for which metatomic should compute the energy

--- a/src/gromacs/applied_forces/metatomic/tests/metatomic_options.cpp
+++ b/src/gromacs/applied_forces/metatomic/tests/metatomic_options.cpp
@@ -103,6 +103,16 @@ public:
         mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-device", std::string("cpu"));
         mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-variant",
                                               std::string(""));
+        mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-uncertainty-threshold",
+                                              std::string("auto"));
+        mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-variant-energy-uq",
+                                              std::string(""));
+        mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-non-conservative",
+                                              std::string("false"));
+        mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-variant-nc-forces",
+                                              std::string(""));
+        mdpValueBuilder.rootObject().addValue(METATOMIC_MODULE_NAME + "-variant-nc-stress",
+                                              std::string(""));
         return mdpValueBuilder.build();
     }
 

--- a/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_OutputDefaultValuesWhenActive.xml
+++ b/src/gromacs/applied_forces/metatomic/tests/refdata/MetatomicOptionsTest_OutputDefaultValuesWhenActive.xml
@@ -9,6 +9,11 @@ metatomic-model             =
 metatomic-extensions        = 
 metatomic-check-consistency = true
 metatomic-device            = 
-metatomic-variant           = 
+metatomic-variant           =
+metatomic-uncertainty-threshold = auto
+metatomic-variant-energy-uq =
+metatomic-non-conservative  = false
+metatomic-variant-nc-forces =
+metatomic-variant-nc-stress =
 </String>
 </ReferenceData>


### PR DESCRIPTION
## Summary

- **O(N²) pair exchange → O(total_pairs) ring exchange**: `exchangeBackwardPairs()` replaced dense `N²×sizeof(int)` pair table allreduce (400 MB for 10K atoms) with ring-based `MPI_Sendrecv` in P-1 rounds. Uses `unordered_set` with `PairHash` for O(1) lookup.
- **O(N_total) force allreduce → sparse indexed exchange**: Home forces applied directly; non-home forces packed as sparse `(idx, fx, fy, fz)` tuples and exchanged via `MPI_Gatherv + MPI_Bcast`. Dense fallback for N < 1000.
- **ASV benchmark suite**: Serial, DD4-full, DD4-pairlist benchmarks following the eOn layout. CI workflows for automated PR comparison via `asv-spyglass`.

## Benchmark results (125-atom LJ, 100 steps, thread-MPI)

| Change | Before (realDomDec) | After (ddScaling) | Ratio | Benchmark |
|--------|-------|-------|-------|-----------|
| **-51%** | 2.34s | 1.13s | 0.49 | DD4 full NL (pair exchange + force scatter) |
| ~same | 2.12s | 2.02s | 0.95 | DD4 pairlist NL |
| ~same | 1.51s | 1.40s | 0.93 | Serial |

The DD4 full NL speedup is entirely from the ring pair exchange replacing the N² table.

See [`pixi_envs` readme.org](https://github.com/HaoZeke/pixi_envs/blob/main/orgs/metatensor/gromacs/readme.org#benchmarks) for local benchmark instructions.

## Checklist
- [x] All 13 tests pass (`-k "not dd8 and not dd12"`)
- [x] Serial ↔ DD4 energy match for both NL modes
- [x] No tolerance changes needed
- [ ] CUDA build + full test suite on remote (dd8/dd12)
