### PR TITLE
perf(mta): GPU-resident metatomic force provider

### DIFF
--- a/.github/workflows/ci_bench_commenter.yml
+++ b/.github/workflows/ci_bench_commenter.yml
@@ -1,7 +1,7 @@
 name: Comment benchmark results
 on:
   workflow_run:
-    workflows: ["Benchmark PR"]
+    workflows: ["Benchmark PR", "GPU Benchmark PR"] 
     types: [completed]
 
 jobs:
@@ -31,4 +31,5 @@ jobs:
           auto-draft-on-regression: "false"
           label-before: base
           label-after: pr
-          runner-info: ubuntu-24.04
+          # Dynamically set the comment title based on which workflow triggered it
+          runner-info: ${{ github.event.workflow_run.name == 'GPU Benchmark PR' && 'self-hosted-cuda' || 'ubuntu-24.04' }}

--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Initialise ASV machine
         working-directory: pixi_envs/orgs/metatensor/gromacs
-        run: pixi run -e metatomic-cpu bash -c "asv machine --yes"
+        run: pixi run -e metatomic-cpu python -m asv machine --yes
 
       - name: Record commit SHAs
         id: shas
@@ -66,8 +66,7 @@ jobs:
         env:
           GMX_BIN: ${{ github.workspace }}/pixi_envs/orgs/metatensor/gromacs/.pixi/envs/metatomic-cpu/bin/gmx
         run: |
-          pixi run -e metatomic-cpu bash -c \
-            "asv run -E 'existing:\$(which python)' --set-commit-hash ${{ steps.shas.outputs.base }} --record-samples --quick"
+          pixi run -e metatomic-cpu python -m asv run -E existing --set-commit-hash ${{ steps.shas.outputs.base }} --record-samples --quick
 
       # -- Benchmark PR HEAD --------------------------------------------
       - name: Build GROMACS (PR)
@@ -83,16 +82,14 @@ jobs:
         env:
           GMX_BIN: ${{ github.workspace }}/pixi_envs/orgs/metatensor/gromacs/.pixi/envs/metatomic-cpu/bin/gmx
         run: |
-          pixi run -e metatomic-cpu bash -c \
-            "asv run -E 'existing:\$(which python)' --set-commit-hash ${{ steps.shas.outputs.pr }} --record-samples --quick"
+          pixi run -e metatomic-cpu python -m asv run -E existing --set-commit-hash ${{ steps.shas.outputs.pr }} --record-samples --quick
 
       # -- Compare and upload -------------------------------------------
       - name: Generate comparison
         working-directory: pixi_envs/orgs/metatensor/gromacs
         run: |
           mkdir -p results
-          pixi run -e metatomic-cpu bash -c \
-            "asv compare ${{ steps.shas.outputs.base }} ${{ steps.shas.outputs.pr }}" > results/comparison.txt || true
+          pixi run -e metatomic-cpu python -m asv compare ${{ steps.shas.outputs.base }} ${{ steps.shas.outputs.pr }} > results/comparison.txt || true
           cat results/comparison.txt
 
       - name: Write metadata

--- a/.github/workflows/gpu_bench.yaml
+++ b/.github/workflows/gpu_bench.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Initialise ASV machine
         working-directory: pixi_envs/orgs/metatensor/gromacs
-        run: pixi run -e metatomic-cuda bash -c "asv machine --yes"
+        run: pixi run -e metatomic-cuda python -m asv machine --yes
 
       - name: Record commit SHAs
         id: shas
@@ -78,8 +78,7 @@ jobs:
         env:
           GMX_BIN: ${{ github.workspace }}/pixi_envs/orgs/metatensor/gromacs/.pixi/envs/metatomic-cuda/bin/gmx
         run: |
-          pixi run -e metatomic-cuda bash -c \
-            "asv run -E 'existing:\$(which python)' --set-commit-hash ${{ steps.shas.outputs.base }} --record-samples --quick"
+          pixi run -e metatomic-cuda python -m asv run -E existing --set-commit-hash ${{ steps.shas.outputs.base }} --record-samples --quick
 
       # -- Benchmark PR HEAD --------------------------------------------
       - name: Build GROMACS (PR)
@@ -95,16 +94,14 @@ jobs:
         env:
           GMX_BIN: ${{ github.workspace }}/pixi_envs/orgs/metatensor/gromacs/.pixi/envs/metatomic-cuda/bin/gmx
         run: |
-          pixi run -e metatomic-cuda bash -c \
-            "asv run -E 'existing:\$(which python)' --set-commit-hash ${{ steps.shas.outputs.pr }} --record-samples --quick"
+          pixi run -e metatomic-cuda python -m asv run -E existing --set-commit-hash ${{ steps.shas.outputs.pr }} --record-samples --quick
 
       # -- Compare and upload -------------------------------------------
       - name: Generate comparison
         working-directory: pixi_envs/orgs/metatensor/gromacs
         run: |
           mkdir -p results
-          pixi run -e metatomic-cuda bash -c \
-            "asv compare ${{ steps.shas.outputs.base }} ${{ steps.shas.outputs.pr }}" > results/comparison.txt || true
+          pixi run -e metatomic-cuda python -m asv compare ${{ steps.shas.outputs.base }} ${{ steps.shas.outputs.pr }} > results/comparison.txt || true
           cat results/comparison.txt
 
       - name: Write metadata

--- a/.github/workflows/gpu_bench.yaml
+++ b/.github/workflows/gpu_bench.yaml
@@ -1,0 +1,125 @@
+name: GPU Benchmark PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+on:
+  pull_request:
+
+jobs:
+  benchmark:
+    runs-on: self-hosted
+    # PRIMARY GATE: Block all forks. Only runs on branches pushed directly to the main repository.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      # SECONDARY GATE: Require a specific repository secret to execute.
+      - name: Authorize Execution
+        env:
+          SECURE_GATE: ${{ secrets.CUDA_RUNNER_SECRET }}
+        run: |
+          if [ -z "$SECURE_GATE" ]; then
+            echo "::error::Unauthorized: Missing required repository secret."
+            exit 1
+          fi
+
+      - name: Checkout GROMACS
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: gromacs
+
+      - name: Checkout pixi_envs
+        uses: actions/checkout@v4
+        with:
+          repository: HaoZeke/pixi_envs
+          ref: main
+          path: pixi_envs
+
+      - name: Place GROMACS inside pixi_envs layout
+        run: ln -s ${{ github.workspace }}/gromacs pixi_envs/orgs/metatensor/gromacs/gromacs
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          manifest-path: pixi_envs/orgs/metatensor/gromacs/pixi.toml
+          environments: metatomic-cuda
+
+      - name: Install ASV
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: pixi run -e metatomic-cuda pip install asv
+
+      - name: Initialise ASV machine
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: pixi run -e metatomic-cuda bash -c "asv machine --yes"
+
+      - name: Record commit SHAs
+        id: shas
+        working-directory: gromacs
+        run: |
+          echo "pr=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          echo "base=$(git rev-parse origin/${{ github.event.pull_request.base.ref }})" >> "$GITHUB_OUTPUT"
+
+      # -- Benchmark base -----------------------------------------------
+      - name: Build GROMACS (base)
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: |
+          git -C ${{ github.workspace }}/gromacs checkout -f ${{ steps.shas.outputs.base }}
+          pixi run -e metatomic-cuda gromk-tmpi Release
+
+      - name: Generate test model (base)
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: |
+          pixi run -e metatomic-cuda python benchmarks/data/create_model.py
+          mv model.pt benchmarks/data/
+
+      - name: Benchmark base
+        id: bench_base
+        continue-on-error: true
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        env:
+          GMX_BIN: ${{ github.workspace }}/pixi_envs/orgs/metatensor/gromacs/.pixi/envs/metatomic-cuda/bin/gmx
+        run: |
+          pixi run -e metatomic-cuda bash -c \
+            "asv run -E 'existing:\$(which python)' --set-commit-hash ${{ steps.shas.outputs.base }} --record-samples --quick"
+
+      # -- Benchmark PR HEAD --------------------------------------------
+      - name: Build GROMACS (PR)
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: |
+          git -C ${{ github.workspace }}/gromacs checkout -f ${{ steps.shas.outputs.pr }}
+          pixi run -e metatomic-cuda gromk-tmpi Release
+
+      - name: Benchmark PR
+        id: bench_pr
+        continue-on-error: true
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        env:
+          GMX_BIN: ${{ github.workspace }}/pixi_envs/orgs/metatensor/gromacs/.pixi/envs/metatomic-cuda/bin/gmx
+        run: |
+          pixi run -e metatomic-cuda bash -c \
+            "asv run -E 'existing:\$(which python)' --set-commit-hash ${{ steps.shas.outputs.pr }} --record-samples --quick"
+
+      # -- Compare and upload -------------------------------------------
+      - name: Generate comparison
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: |
+          mkdir -p results
+          pixi run -e metatomic-cuda bash -c \
+            "asv compare ${{ steps.shas.outputs.base }} ${{ steps.shas.outputs.pr }}" > results/comparison.txt || true
+          cat results/comparison.txt
+
+      - name: Write metadata
+        working-directory: pixi_envs/orgs/metatensor/gromacs
+        run: |
+          cat > results/metadata.txt <<EOF
+          base=${{ steps.shas.outputs.base }}
+          contender=${{ steps.shas.outputs.pr }}
+          pr=${{ github.event.pull_request.number }}
+          EOF
+          sed -i 's/^[[:space:]]*//' results/metadata.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: pixi_envs/orgs/metatensor/gromacs/results/
+          retention-days: 7

--- a/.github/workflows/metatomic-ci.yml
+++ b/.github/workflows/metatomic-ci.yml
@@ -70,10 +70,10 @@ jobs:
         working-directory: pixi_envs/orgs/metatensor/gromacs
         run: cd mta_test && pixi run -e metatomic-cpu python create_model.py
 
-      - name: Run tests (skip dd8/dd12)
+      - name: Run tests (skip dd8/dd12/gpu)
         working-directory: pixi_envs/orgs/metatensor/gromacs
         env:
           GMX_BIN: ${{ matrix.gmx_bin }}
         run: |
           pixi run -e metatomic-cpu pytest mta_test/ -v \
-            -m "not dd8 and not dd12"
+            -m "not dd8 and not dd12 and not gpu"

--- a/src/gromacs/applied_forces/metatomic/CMakeLists.txt
+++ b/src/gromacs/applied_forces/metatomic/CMakeLists.txt
@@ -34,17 +34,29 @@
 gmx_add_libgromacs_sources(
     metatomic_options.cpp
     metatomic_mdmodule.cpp
+    metatomic_gpu_mdmodule.cpp
 )
 
 if (GMX_METATOMIC)
     gmx_add_libgromacs_sources(
         metatomic_forceprovider.cpp
     )
-if (BUILD_TESTING)
-    add_subdirectory(tests)
-endif()
+    if (GMX_GPU_CUDA)
+        gmx_add_libgromacs_sources(
+            metatomic_gpu_forceprovider.cpp
+            metatomic_gpu_pairlist_kernel.cu
+        )
+    else()
+        gmx_add_libgromacs_sources(
+            metatomic_gpu_forceprovider_stub.cpp
+        )
+    endif()
+    if (BUILD_TESTING)
+        add_subdirectory(tests)
+    endif()
 else()
     gmx_add_libgromacs_sources(
         metatomic_forceprovider_stub.cpp
+        metatomic_gpu_forceprovider_stub.cpp
     )
 endif()

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
@@ -40,7 +40,8 @@
  *
  * Single-rank: forces via GpuForceReduction (pure GPU path, no D2H copies).
  * Domain decomposition: GPU model evaluation + CPU-side sparse force exchange.
- * Uses the "pairlist" DD mode from the CPU metatomic path.
+ * GPU-resident (zero-copy) path is single-rank only; DD mode uses CPU force
+ * distribution via distributeNonHomeForces.
  *
  * \ingroup module_applied_forces
  */
@@ -268,9 +269,11 @@ MetatomicGpuForceProvider::Impl::Impl(const MetatomicParameters& params,
     capabilities_ = model_.run_method("capabilities")
                              .toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
 
-    // Determine CUDA device
+    // Determine CUDA device and verify it matches the GROMACS DeviceContext
     int cudaDevice = 0;
     cudaGetDevice(&cudaDevice);
+    GMX_RELEASE_ASSERT(deviceContext_.deviceInfo().id == cudaDevice,
+                       "GROMACS DeviceContext and CUDA current device disagree");
     device_ = torch::Device(torch::kCUDA, cudaDevice);
 
     // Set GROMACS CUDA stream as LibTorch's current stream to avoid inter-stream sync
@@ -734,6 +737,18 @@ void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
                 cA[0][0], cA[1][1], cA[2][2]);
     }
 
+    // In debug mode, checksum a sample of the raw coordinate buffer before
+    // model evaluation to verify the assumption that d_x is stable (not mutated
+    // by another stream) during the metatomic call.
+    torch::Tensor coordChecksumPre;
+    if (debugEnabled_)
+    {
+        auto rawCoords = torch::from_blob(static_cast<void*>(d_x),
+                                           { static_cast<int64_t>(modelNumAtoms), 3 },
+                                           coordOptions);
+        coordChecksumPre = rawCoords.sum().detach().clone();
+    }
+
     // Forward pass
     metatensor_torch::TensorMap outputMap;
     try
@@ -768,6 +783,19 @@ void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
     positions.mutable_grad() = torch::Tensor();
     strain.mutable_grad()    = torch::Tensor();
     energyTensor.backward(-torch::ones_like(energyTensor));
+
+    // Verify coordinate buffer was not mutated during model evaluation
+    if (debugEnabled_ && coordChecksumPre.defined())
+    {
+        auto rawCoords = torch::from_blob(static_cast<void*>(d_x),
+                                           { static_cast<int64_t>(modelNumAtoms), 3 },
+                                           coordOptions);
+        auto coordChecksumPost = rawCoords.sum();
+        auto diff = (coordChecksumPost - coordChecksumPre).abs().item<float>();
+        GMX_RELEASE_ASSERT(diff < 1e-6f,
+                           "Coordinate buffer d_x was mutated during metatomic model evaluation. "
+                           "This indicates a stream synchronization or aliasing bug.");
+    }
 
     // Forces = position gradients (already negated by backward with -1)
     auto forces = positions.grad(); // [modelNumAtoms, 3] on CUDA

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
@@ -130,7 +130,8 @@ public:
                          const GpuPairlist*    gpuPairlist,
                          DeviceBuffer<int>     d_atomIndex,
                          const NBAtomDataGpu*  nbAtomData,
-                         bool                  isNsStep);
+                         bool                  isNsStep,
+                         GpuEventSynchronizer* xReadyOnDevice);
 
     void updateAtomMapping(int numHomeAtoms, int numTotalAtoms, const int* globalAtomIndices);
 
@@ -334,6 +335,7 @@ MetatomicGpuForceProvider::Impl::Impl(const MetatomicParameters& params,
     auto requestedOutput = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
     requestedOutput->per_atom           = modelOutput->per_atom;
     requestedOutput->explicit_gradients = {};
+    requestedOutput->set_quantity("energy");
     requestedOutput->set_unit("kJ/mol");
     evaluationOptions_->outputs.insert(energyKey, requestedOutput);
 
@@ -552,8 +554,54 @@ void MetatomicGpuForceProvider::Impl::buildNeighborListGpu(const GpuPairlist*   
     auto intOptions   = torch::TensorOptions().dtype(torch::kInt32).device(device_);
     auto floatOptions = torch::TensorOptions().dtype(torch::kFloat32).device(device_);
 
-    nlSamples_   = torch::from_blob(d_nlSamples_, { numPairs, 5 }, intOptions);
-    nlDistances_ = torch::from_blob(d_nlDistances_, { numPairs, 3, 1 }, floatOptions);
+    auto halfSamples   = torch::from_blob(d_nlSamples_, { numPairs, 5 }, intOptions);
+    auto halfDistances = torch::from_blob(d_nlDistances_, { numPairs, 3, 1 }, floatOptions);
+
+    // The nbnxm GPU pairlist is approximately a half-list, but some pairs
+    // may appear in both directions due to overlapping super-clusters.
+    // ML models require a full list with both (i,j) and (j,i).
+    // Strategy: create all reverses, concatenate, then deduplicate.
+    auto revSamples = torch::empty_like(halfSamples);
+    revSamples.index({ torch::indexing::Slice(), 0 }) =
+            halfSamples.index({ torch::indexing::Slice(), 1 }); // j -> i
+    revSamples.index({ torch::indexing::Slice(), 1 }) =
+            halfSamples.index({ torch::indexing::Slice(), 0 }); // i -> j
+    revSamples.index({ torch::indexing::Slice(), torch::indexing::Slice(2, 5) }) =
+            -halfSamples.index({ torch::indexing::Slice(), torch::indexing::Slice(2, 5) });
+
+    auto revDistances = -halfDistances;
+
+    auto allSamples   = torch::cat({ halfSamples, revSamples }, /*dim=*/0);
+    auto allDistances = torch::cat({ halfDistances, revDistances }, /*dim=*/0);
+
+    // Deduplicate: encode each 5-column row as a single int64 key,
+    // sort, then keep only the first occurrence of each key.
+    {
+        auto s64       = allSamples.to(torch::kInt64);
+        constexpr int64_t D = 50; // shift offset (shifts are small integers)
+        constexpr int64_t M = 100000; // multiplier (> max atom index + 2*D)
+        auto col0 = s64.index({ torch::indexing::Slice(), 0 });
+        auto col1 = s64.index({ torch::indexing::Slice(), 1 });
+        auto col2 = s64.index({ torch::indexing::Slice(), 2 }) + D;
+        auto col3 = s64.index({ torch::indexing::Slice(), 3 }) + D;
+        auto col4 = s64.index({ torch::indexing::Slice(), 4 }) + D;
+        auto keys = ((((col0 * M + col1) * M + col2) * M + col3) * M + col4);
+
+        // Sort by key, then keep rows where key differs from predecessor
+        auto [sortedKeys, sortIdx] = keys.sort();
+        auto uniqueMask = torch::ones({ sortedKeys.size(0) },
+                                       torch::TensorOptions().dtype(torch::kBool).device(device_));
+        if (sortedKeys.size(0) > 1)
+        {
+            uniqueMask.index({ torch::indexing::Slice(1, torch::indexing::None) }) =
+                    sortedKeys.index({ torch::indexing::Slice(1, torch::indexing::None) })
+                    != sortedKeys.index({ torch::indexing::Slice(torch::indexing::None, -1) });
+        }
+        auto keepIdx = sortIdx.index({ uniqueMask });
+
+        nlSamples_   = allSamples.index_select(0, keepIdx);
+        nlDistances_ = allDistances.index_select(0, keepIdx);
+    }
 
     if (dtype_ == torch::kFloat64)
     {
@@ -569,9 +617,19 @@ void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
                                                         const GpuPairlist*    gpuPairlist,
                                                         DeviceBuffer<int>     d_atomIndex,
                                                         const NBAtomDataGpu*  nbAtomData,
-                                                        bool                  isNsStep)
+                                                        bool                  isNsStep,
+                                                        GpuEventSynchronizer* xReadyOnDevice)
 {
     GMX_RELEASE_ASSERT(atomMappingReady_, "updateAtomMapping must be called before calculateForces");
+
+    // Wait for coordinates to be ready on the GPU.
+    // The H2D copy runs on the StatePropagatorDataGpu stream; we insert
+    // a barrier into the metatomic (NonBondedLocal) stream so that all
+    // subsequent torch/CUDA work sees the updated coordinates.
+    if (xReadyOnDevice != nullptr)
+    {
+        xReadyOnDevice->enqueueWaitEvent(deviceStream_);
+    }
 
     // In DD mode, use the total local atom count (home + halo) for model input.
     // The caller passes mdatoms->homenr, but we need all local atoms.
@@ -656,6 +714,26 @@ void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
     // Serial mode: same.
     evaluationOptions_->set_selected_atoms(torch::nullopt);
 
+    // Debug: print diagnostics
+    if (debugEnabled_)
+    {
+        auto posHost = positions.detach().to(torch::kCPU).to(torch::kFloat64);
+        auto cellCpu = cell.to(torch::kCPU).to(torch::kFloat64);
+        auto pA = posHost.accessor<double, 2>();
+        auto cA = cellCpu.accessor<double, 2>();
+        fprintf(stderr,
+                "[MetatomicGpu] step=%ld atoms=%d NL_pairs=%ld\n"
+                "  pos[0] = (%.6f, %.6f, %.6f)\n"
+                "  pos[1] = (%.6f, %.6f, %.6f)\n"
+                "  cell = diag(%.6f, %.6f, %.6f)\n",
+                step,
+                modelNumAtoms,
+                nlSamples_.numel() > 0 ? nlSamples_.size(0) : 0L,
+                pA[0][0], pA[0][1], pA[0][2],
+                pA[1][0], pA[1][1], pA[1][2],
+                cA[0][0], cA[1][1], cA[2][2]);
+    }
+
     // Forward pass
     metatensor_torch::TensorMap outputMap;
     try
@@ -677,6 +755,14 @@ void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
 
     // Extract energy (always needed for logging/output)
     cachedEnergy_ = energyTensor.sum().item<double>();
+
+    if (debugEnabled_)
+    {
+        fprintf(stderr, "[MetatomicGpu] energy = %.6f (per_atom tensor shape: [%ld, %ld])\n",
+                cachedEnergy_,
+                energyTensor.size(0),
+                energyTensor.size(1));
+    }
 
     // Backward pass: compute forces via autograd
     positions.mutable_grad() = torch::Tensor();
@@ -877,9 +963,10 @@ void MetatomicGpuForceProvider::calculateForces(DeviceBuffer<RVec>    d_x,
                                                  const GpuPairlist*    gpuPairlist,
                                                  DeviceBuffer<int>     d_atomIndex,
                                                  const NBAtomDataGpu*  nbAtomData,
-                                                 bool                  isNsStep)
+                                                 bool                  isNsStep,
+                                                 GpuEventSynchronizer* xReadyOnDevice)
 {
-    impl_->calculateForces(d_x, numAtoms, box, step, gpuPairlist, d_atomIndex, nbAtomData, isNsStep);
+    impl_->calculateForces(d_x, numAtoms, box, step, gpuPairlist, d_atomIndex, nbAtomData, isNsStep, xReadyOnDevice);
 }
 
 void MetatomicGpuForceProvider::updateAtomMapping(int        numHomeAtoms,

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
@@ -59,6 +59,7 @@
 
 #include "gromacs/gpu_utils/device_context.h"
 #include "gromacs/gpu_utils/device_stream.h"
+#include "gromacs/hardware/device_information.h"
 #include "gromacs/gpu_utils/devicebuffer.h"
 #include "gromacs/gpu_utils/gpueventsynchronizer.h"
 #include "gromacs/mdtypes/enerdata.h"

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
@@ -1,0 +1,908 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements the GPU-resident Metatomic Force Provider.
+ *
+ * Zero-copy coordinate wrapping, GPU neighbor list construction from nbnxm
+ * GpuPairlist, and GPU-resident model evaluation with force output.
+ *
+ * Single-rank: forces via GpuForceReduction (pure GPU path, no D2H copies).
+ * Domain decomposition: GPU model evaluation + CPU-side sparse force exchange.
+ * Uses the "pairlist" DD mode from the CPU metatomic path.
+ *
+ * \ingroup module_applied_forces
+ */
+#include "gmxpre.h"
+
+#include "metatomic_gpu_forceprovider.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gromacs/gpu_utils/device_context.h"
+#include "gromacs/gpu_utils/device_stream.h"
+#include "gromacs/gpu_utils/devicebuffer.h"
+#include "gromacs/gpu_utils/gpueventsynchronizer.h"
+#include "gromacs/mdtypes/enerdata.h"
+#include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/nbnxm/gpu_types_common.h"
+#include "gromacs/nbnxm/nbnxm_enums.h"
+#include "gromacs/utility/exceptions.h"
+#include "gromacs/utility/logger.h"
+#include "gromacs/utility/mpicomm.h"
+
+#include "metatomic_gpu_pairlist_kernel.cuh"
+#include "metatomic_options.h"
+
+#ifdef DIM
+#    undef DIM
+#endif
+
+#include <metatensor/torch.hpp>
+#include <metatomic/torch.hpp>
+
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_runtime.h>
+
+namespace gmx
+{
+
+/*! \brief Normalizes the variant string for GPU path (same logic as CPU path). */
+static torch::optional<std::string> normalizeVariantGpu(std::string variant_string)
+{
+    if (variant_string == "no" || variant_string.empty())
+    {
+        return torch::nullopt;
+    }
+    return variant_string;
+}
+
+/*! \brief Pick the energy output key from model capabilities. */
+static std::string pickOutputGpu(const std::string&                         baseName,
+                                  const metatomic_torch::ModelCapabilities& caps,
+                                  torch::optional<std::string>              variant)
+{
+    auto outputs = caps->outputs();
+    if (variant.has_value())
+    {
+        std::string key = baseName + "::" + variant.value();
+        if (outputs.contains(key))
+        {
+            return key;
+        }
+    }
+    return baseName;
+}
+
+/*! \brief Implementation class hiding torch/CUDA/MPI dependencies. */
+class MetatomicGpuForceProvider::Impl
+{
+public:
+    Impl(const MetatomicParameters& params,
+         const MDLogger&            logger,
+         const DeviceContext&       deviceContext,
+         const DeviceStream&        deviceStream,
+         const MpiComm&             mpiComm,
+         std::vector<int>           globalAtomicNumbers);
+    ~Impl();
+
+    void calculateForces(DeviceBuffer<RVec>    d_x,
+                         int                   numAtoms,
+                         const matrix          box,
+                         int64_t               step,
+                         const GpuPairlist*    gpuPairlist,
+                         DeviceBuffer<int>     d_atomIndex,
+                         const NBAtomDataGpu*  nbAtomData,
+                         bool                  isNsStep);
+
+    void updateAtomMapping(int numHomeAtoms, int numTotalAtoms, const int* globalAtomIndices);
+
+    void applyOutputs(gmx_enerdata_t* enerd, ForceWithVirial* forceWithVirial);
+
+    DeviceBuffer<RVec>    getForceDeviceBuffer() { return forceBuffer_; }
+    GpuEventSynchronizer* getCompletionEvent() { return completionEvent_.get(); }
+    bool                  hasDomainDecomposition() const { return isDD_; }
+
+private:
+    void buildNeighborListGpu(const GpuPairlist*   gpuPairlist,
+                              DeviceBuffer<int>    d_atomIndex,
+                              const NBAtomDataGpu* nbAtomData,
+                              int                  numAtoms,
+                              const matrix         box);
+
+    void distributeNonHomeForces(ForceWithVirial* forceWithVirial);
+
+    const DeviceContext& deviceContext_;
+    const DeviceStream&  deviceStream_;
+    const MDLogger&      logger_;
+    const MpiComm&       mpiComm_;
+
+    //! GPU force output buffer [numAtoms] in natural order
+    DeviceBuffer<RVec> forceBuffer_     = nullptr;
+    int                forceBufferSize_ = 0;
+    std::unique_ptr<GpuEventSynchronizer> completionEvent_;
+
+    //! Metatomic model data
+    metatensor_torch::Module                          model_ = metatensor_torch::Module(torch::jit::Module());
+    metatomic_torch::ModelCapabilities                capabilities_;
+    std::vector<metatomic_torch::NeighborListOptions> nlRequests_;
+    metatomic_torch::ModelEvaluationOptions           evaluationOptions_;
+    torch::ScalarType dtype_  = torch::kFloat32;
+    torch::Device     device_ = torch::Device(torch::kCUDA, 0);
+
+    //! Cached NL Labels
+    metatensor_torch::Labels cachedNLComponent_;
+    metatensor_torch::Labels cachedNLProperties_;
+    std::vector<std::string> nlSampleNames_ = {
+        "first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"
+    };
+
+    //! Cached atom types tensor on GPU (refreshed on atom redistribution)
+    torch::Tensor atomTypes_;
+    torch::Tensor pbc_;
+    int32_t       numAtoms_ = 0;
+
+    //! NL tensors on GPU (refreshed on NS steps from GpuPairlist)
+    torch::Tensor nlSamples_;   //!< [nPairs, 5] int32 on CUDA
+    torch::Tensor nlDistances_; //!< [nPairs, 3, 1] float on CUDA
+
+    //! GPU buffers for NL kernel output (pre-allocated, resized as needed)
+    DeviceBuffer<int32_t> d_nlSamples_   = nullptr;
+    DeviceBuffer<float>   d_nlDistances_ = nullptr;
+    DeviceBuffer<int64_t> d_nlCount_     = nullptr;
+    int64_t               nlCapacity_    = 0;
+
+    //! Model path for error messages
+    std::string modelPath_;
+
+    //! Debug mode flag
+    bool debugEnabled_ = false;
+
+    //! Global atomic numbers indexed by global atom index (set in constructor)
+    std::vector<int> globalAtomicNumbers_;
+
+    // ---- Domain decomposition state ----
+
+    //! Whether DD is active
+    bool isDD_ = false;
+
+    //! Number of home atoms on this rank (DD: < numLocalMta_, serial: == numLocalMta_)
+    int32_t numHomeMta_ = 0;
+
+    //! Number of total local atoms (home + halo) for model input
+    int32_t numLocalMta_ = 0;
+
+    //! Model index -> GROMACS local buffer index (identity in serial)
+    std::vector<int32_t> mtaToGmxLocal_;
+
+    //! Model index -> global atom index (for sparse force exchange)
+    std::vector<int32_t> mtaToGlobalIdx_;
+
+    //! Global atom index -> local home model index (for receiving forces)
+    std::unordered_map<int32_t, int32_t> globalIdxToLocalHome_;
+
+    //! Whether atom mapping has been initialized
+    bool atomMappingReady_ = false;
+
+    // ---- Cached outputs (set by calculateForces, read by applyOutputs) ----
+
+    double cachedEnergy_ = 0.0;
+    matrix cachedVirial_ = { { 0 } };
+
+    //! Host force buffer for DD mode [numLocalMta_ * 3] in double
+    std::vector<double> cachedForcesHost_;
+};
+
+
+MetatomicGpuForceProvider::Impl::Impl(const MetatomicParameters& params,
+                                       const MDLogger&            logger,
+                                       const DeviceContext&       deviceContext,
+                                       const DeviceStream&        deviceStream,
+                                       const MpiComm&             mpiComm,
+                                       std::vector<int>           globalAtomicNumbers) :
+    deviceContext_(deviceContext),
+    deviceStream_(deviceStream),
+    logger_(logger),
+    mpiComm_(mpiComm),
+    completionEvent_(std::make_unique<GpuEventSynchronizer>()),
+    modelPath_(params.modelPath_),
+    globalAtomicNumbers_(std::move(globalAtomicNumbers))
+{
+    GMX_LOG(logger_.info).asParagraph().appendText("Initializing MetatomicGpuForceProvider...");
+
+    debugEnabled_ = (std::getenv("GMX_METATOMIC_DEBUG") != nullptr);
+
+    // Load model
+    try
+    {
+        torch::optional<std::string> extensionsDir = torch::nullopt;
+        if (!params.extensionsDirectory.empty())
+        {
+            extensionsDir = params.extensionsDirectory;
+        }
+        model_ = metatomic_torch::load_atomistic_model(params.modelPath_, extensionsDir);
+    }
+    catch (const std::exception& e)
+    {
+        GMX_THROW(APIError("Failed to load metatomic model for GPU: " + std::string(e.what())));
+    }
+
+    capabilities_ = model_.run_method("capabilities")
+                             .toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
+
+    // Determine CUDA device
+    int cudaDevice = 0;
+    cudaGetDevice(&cudaDevice);
+    device_ = torch::Device(torch::kCUDA, cudaDevice);
+
+    // Set GROMACS CUDA stream as LibTorch's current stream to avoid inter-stream sync
+    auto torchStream = c10::cuda::getStreamFromExternal(
+            deviceStream_.stream(), static_cast<c10::DeviceIndex>(cudaDevice));
+    c10::cuda::setCurrentCUDAStream(torchStream);
+
+    GMX_LOG(logger_.info)
+            .asParagraph()
+            .appendTextFormatted("MetatomicGpu using CUDA device %d, MPI size %d",
+                                 cudaDevice,
+                                 mpiComm_.size());
+
+    // Cache NL labels
+    auto devIntOpts = torch::TensorOptions().dtype(torch::kInt32).device(device_);
+    cachedNLComponent_ = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+            std::vector<std::string>{ "xyz" },
+            torch::tensor({ 0, 1, 2 }, devIntOpts).reshape({ 3, 1 }));
+    cachedNLProperties_ = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+            std::vector<std::string>{ "distance" },
+            torch::zeros({ 1, 1 }, devIntOpts));
+
+    // Get NL requests from model
+    auto requestsIvalue = model_.run_method("requested_neighbor_lists");
+    for (const auto& reqIvalue : requestsIvalue.toList())
+    {
+        nlRequests_.push_back(
+                reqIvalue.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>());
+    }
+
+    model_.to(device_);
+
+    // Determine model dtype
+    if (capabilities_->dtype() == "float64")
+    {
+        dtype_ = torch::kFloat64;
+    }
+    else if (capabilities_->dtype() == "float32")
+    {
+        dtype_ = torch::kFloat32;
+    }
+    else
+    {
+        GMX_THROW(APIError("Unsupported dtype: " + capabilities_->dtype()));
+    }
+
+    // Set up evaluation options
+    evaluationOptions_ = torch::make_intrusive<metatomic_torch::ModelEvaluationOptionsHolder>();
+    evaluationOptions_->set_length_unit("nm");
+
+    auto outputs   = capabilities_->outputs();
+    auto variant   = normalizeVariantGpu(params.variant);
+    auto energyKey = pickOutputGpu("energy", capabilities_, variant);
+
+    if (!outputs.contains(energyKey))
+    {
+        GMX_THROW(
+                APIError("The model does not provide '" + energyKey + "' output for GPU path."));
+    }
+
+    auto modelOutput     = outputs.at(energyKey);
+    auto requestedOutput = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+    requestedOutput->per_atom           = modelOutput->per_atom;
+    requestedOutput->explicit_gradients = {};
+    requestedOutput->set_unit("kJ/mol");
+    evaluationOptions_->outputs.insert(energyKey, requestedOutput);
+
+    // PBC tensor (assume 3D periodic for GPU path)
+    pbc_ = torch::tensor({ true, true, true },
+                          torch::TensorOptions().dtype(torch::kBool).device(device_));
+
+    // Allocate NL counter on GPU
+    allocateDeviceBuffer(&d_nlCount_, 1, deviceContext_);
+
+    GMX_LOG(logger_.info)
+            .asParagraph()
+            .appendText("MetatomicGpuForceProvider initialization complete.");
+}
+
+MetatomicGpuForceProvider::Impl::~Impl()
+{
+    if (forceBuffer_)
+    {
+        freeDeviceBuffer(&forceBuffer_);
+    }
+    if (d_nlSamples_)
+    {
+        freeDeviceBuffer(&d_nlSamples_);
+    }
+    if (d_nlDistances_)
+    {
+        freeDeviceBuffer(&d_nlDistances_);
+    }
+    if (d_nlCount_)
+    {
+        freeDeviceBuffer(&d_nlCount_);
+    }
+}
+
+
+void MetatomicGpuForceProvider::Impl::updateAtomMapping(int        numHomeAtoms,
+                                                         int        numTotalAtoms,
+                                                         const int* globalAtomIndices)
+{
+    mtaToGmxLocal_.clear();
+    mtaToGlobalIdx_.clear();
+    globalIdxToLocalHome_.clear();
+
+    if (globalAtomIndices != nullptr && mpiComm_.isParallel())
+    {
+        // DD mode: map local atoms (home + halo) to global indices
+        isDD_ = true;
+
+        // Home atoms: local indices [0, numHomeAtoms)
+        numHomeMta_ = 0;
+        for (int i = 0; i < numHomeAtoms; i++)
+        {
+            int globalIdx = globalAtomIndices[i];
+            if (globalIdx >= 0) // skip filler particles
+            {
+                mtaToGmxLocal_.push_back(i);
+                mtaToGlobalIdx_.push_back(globalIdx);
+                numHomeMta_++;
+            }
+        }
+
+        // Halo atoms: local indices [numHomeAtoms, numTotalAtoms)
+        for (int i = numHomeAtoms; i < numTotalAtoms; i++)
+        {
+            int globalIdx = globalAtomIndices[i];
+            if (globalIdx >= 0)
+            {
+                mtaToGmxLocal_.push_back(i);
+                mtaToGlobalIdx_.push_back(globalIdx);
+            }
+        }
+
+        numLocalMta_ = static_cast<int32_t>(mtaToGmxLocal_.size());
+
+        // Reverse map: global atom index -> local home model index
+        for (int32_t i = 0; i < numHomeMta_; i++)
+        {
+            globalIdxToLocalHome_[mtaToGlobalIdx_[i]] = i;
+        }
+
+        // Build atom types for all local atoms
+        std::vector<int32_t> atomNumbers(numLocalMta_);
+        for (int32_t i = 0; i < numLocalMta_; i++)
+        {
+            int globalIdx = mtaToGlobalIdx_[i];
+            GMX_RELEASE_ASSERT(globalIdx >= 0
+                                       && globalIdx < static_cast<int>(globalAtomicNumbers_.size()),
+                               "Global atom index out of range in updateAtomMapping");
+            atomNumbers[i] = globalAtomicNumbers_[globalIdx];
+        }
+        atomTypes_ =
+                torch::tensor(atomNumbers, torch::TensorOptions().dtype(torch::kInt32)).to(device_);
+        numAtoms_ = numLocalMta_;
+
+        if (debugEnabled_)
+        {
+            GMX_LOG(logger_.info)
+                    .asParagraph()
+                    .appendTextFormatted(
+                            "MetatomicGpu DD mapping: rank=%d, home=%d, halo=%d, total=%d",
+                            mpiComm_.rank(),
+                            numHomeMta_,
+                            numLocalMta_ - numHomeMta_,
+                            numLocalMta_);
+        }
+    }
+    else
+    {
+        // Serial / single-rank: identity mapping, all atoms are home
+        isDD_        = false;
+        numHomeMta_  = numTotalAtoms;
+        numLocalMta_ = numTotalAtoms;
+        numAtoms_    = numTotalAtoms;
+
+        std::vector<int32_t> atomNumbers(numTotalAtoms);
+        for (int i = 0; i < numTotalAtoms; i++)
+        {
+            atomNumbers[i] = globalAtomicNumbers_[i];
+        }
+        atomTypes_ =
+                torch::tensor(atomNumbers, torch::TensorOptions().dtype(torch::kInt32)).to(device_);
+    }
+
+    atomMappingReady_ = true;
+}
+
+
+void MetatomicGpuForceProvider::Impl::buildNeighborListGpu(const GpuPairlist*   gpuPairlist,
+                                                            DeviceBuffer<int>    d_atomIndex,
+                                                            const NBAtomDataGpu* nbAtomData,
+                                                            int                  numAtoms,
+                                                            const matrix         box)
+{
+    if (!gpuPairlist || gpuPairlist->numSci <= 0)
+    {
+        return;
+    }
+
+    GMX_ASSERT(nbAtomData != nullptr, "NBAtomDataGpu must be valid for GPU NL construction");
+
+    // Get cutoff from the first NL request
+    float cutoff = 0.0f;
+    if (!nlRequests_.empty())
+    {
+        cutoff = static_cast<float>(nlRequests_[0]->engine_cutoff("nm"));
+    }
+    const float cutoffSq = cutoff * cutoff;
+
+    // Initial capacity estimate: ~20 pairs per atom (typical for ML potentials)
+    if (nlCapacity_ == 0)
+    {
+        nlCapacity_ = static_cast<int64_t>(numAtoms) * 20;
+        allocateDeviceBuffer(&d_nlSamples_, nlCapacity_ * 5, deviceContext_);
+        allocateDeviceBuffer(&d_nlDistances_, nlCapacity_ * 3, deviceContext_);
+    }
+
+    // Reset counter to 0
+    int64_t zero = 0;
+    copyToDeviceBuffer(
+            &d_nlCount_, &zero, 0, 1, deviceStream_, GpuApiCallBehavior::Async, nullptr);
+
+    // Extract nbnxm atom data for the kernel
+    const auto* d_xq       = reinterpret_cast<const float4*>(nbAtomData->xq);
+    const auto* d_shiftVec = reinterpret_cast<const float3*>(nbAtomData->shiftVec);
+
+    launchConvertPairlistToMetatomicKernel(gpuPairlist->sci,
+                                           gpuPairlist->cjPacked,
+                                           d_atomIndex,
+                                           d_xq,
+                                           d_shiftVec,
+                                           d_nlSamples_,
+                                           d_nlDistances_,
+                                           d_nlCount_,
+                                           nlCapacity_,
+                                           cutoffSq,
+                                           gpuPairlist->numSci,
+                                           deviceStream_);
+
+    // Check for overflow: copy counter back
+    int64_t numPairs = 0;
+    copyFromDeviceBuffer(
+            &numPairs, &d_nlCount_, 0, 1, deviceStream_, GpuApiCallBehavior::Sync, nullptr);
+
+    if (numPairs > nlCapacity_)
+    {
+        // Overflow: reallocate 2x and rerun
+        freeDeviceBuffer(&d_nlSamples_);
+        freeDeviceBuffer(&d_nlDistances_);
+        nlCapacity_ = numPairs * 2;
+        allocateDeviceBuffer(&d_nlSamples_, nlCapacity_ * 5, deviceContext_);
+        allocateDeviceBuffer(&d_nlDistances_, nlCapacity_ * 3, deviceContext_);
+
+        zero = 0;
+        copyToDeviceBuffer(
+                &d_nlCount_, &zero, 0, 1, deviceStream_, GpuApiCallBehavior::Async, nullptr);
+
+        launchConvertPairlistToMetatomicKernel(gpuPairlist->sci,
+                                               gpuPairlist->cjPacked,
+                                               d_atomIndex,
+                                               d_xq,
+                                               d_shiftVec,
+                                               d_nlSamples_,
+                                               d_nlDistances_,
+                                               d_nlCount_,
+                                               nlCapacity_,
+                                               cutoffSq,
+                                               gpuPairlist->numSci,
+                                               deviceStream_);
+
+        copyFromDeviceBuffer(
+                &numPairs, &d_nlCount_, 0, 1, deviceStream_, GpuApiCallBehavior::Sync, nullptr);
+    }
+
+    // Wrap GPU buffers as torch tensors (zero-copy)
+    auto intOptions   = torch::TensorOptions().dtype(torch::kInt32).device(device_);
+    auto floatOptions = torch::TensorOptions().dtype(torch::kFloat32).device(device_);
+
+    nlSamples_   = torch::from_blob(d_nlSamples_, { numPairs, 5 }, intOptions);
+    nlDistances_ = torch::from_blob(d_nlDistances_, { numPairs, 3, 1 }, floatOptions);
+
+    if (dtype_ == torch::kFloat64)
+    {
+        nlDistances_ = nlDistances_.to(torch::kFloat64);
+    }
+}
+
+
+void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
+                                                        int                   numAtoms,
+                                                        const matrix          box,
+                                                        int64_t               step,
+                                                        const GpuPairlist*    gpuPairlist,
+                                                        DeviceBuffer<int>     d_atomIndex,
+                                                        const NBAtomDataGpu*  nbAtomData,
+                                                        bool                  isNsStep)
+{
+    GMX_RELEASE_ASSERT(atomMappingReady_, "updateAtomMapping must be called before calculateForces");
+
+    // In DD mode, use the total local atom count (home + halo) for model input.
+    // The caller passes mdatoms->homenr, but we need all local atoms.
+    const int modelNumAtoms = isDD_ ? numLocalMta_ : numAtoms;
+
+    // Ensure force buffer is large enough (for single-rank GPU path)
+    if (!isDD_ && modelNumAtoms > forceBufferSize_)
+    {
+        if (forceBuffer_)
+        {
+            freeDeviceBuffer(&forceBuffer_);
+        }
+        allocateDeviceBuffer(&forceBuffer_, modelNumAtoms, deviceContext_);
+        forceBufferSize_ = modelNumAtoms;
+    }
+
+    if (!isDD_)
+    {
+        clearDeviceBufferAsync(&forceBuffer_, 0, modelNumAtoms, deviceStream_);
+    }
+
+    // Build NL on NS steps
+    if (isNsStep)
+    {
+        buildNeighborListGpu(gpuPairlist, d_atomIndex, nbAtomData, modelNumAtoms, box);
+    }
+
+    // Zero-copy wrap GPU coordinates as torch tensor
+    auto coordOptions =
+            torch::TensorOptions()
+                    .dtype(std::is_same_v<real, double> ? torch::kFloat64 : torch::kFloat32)
+                    .device(device_);
+    auto positions = torch::from_blob(static_cast<void*>(d_x),
+                                       { static_cast<int64_t>(modelNumAtoms), 3 },
+                                       coordOptions)
+                             .to(dtype_)
+                             .set_requires_grad(true);
+
+    // Build cell tensor from box (host -> device)
+    auto cellHost = torch::from_blob(
+            const_cast<real*>(&box[0][0]),
+            { 3, 3 },
+            torch::TensorOptions().dtype(
+                    std::is_same_v<real, double> ? torch::kFloat64 : torch::kFloat32));
+    auto cell = cellHost.to(device_, dtype_);
+
+    // Strain tensor for virial computation
+    auto strain = torch::eye(
+            3, torch::TensorOptions().dtype(dtype_).device(device_).requires_grad(true));
+    auto strainedCell      = torch::matmul(cell, strain);
+    auto strainedPositions = torch::matmul(positions, strain);
+
+    // Construct metatensor System (all tensors on GPU)
+    auto system = torch::make_intrusive<metatomic_torch::SystemHolder>(
+            atomTypes_, strainedPositions, strainedCell, pbc_);
+
+    // Add neighbor lists
+    for (const auto& request : nlRequests_)
+    {
+        if (nlSamples_.numel() == 0)
+        {
+            continue;
+        }
+
+        auto neighborSamples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+                nlSampleNames_, nlSamples_);
+        auto neighbors = torch::make_intrusive<metatensor_torch::TensorBlockHolder>(
+                nlDistances_,
+                neighborSamples,
+                std::vector<metatensor_torch::Labels>{ cachedNLComponent_ },
+                cachedNLProperties_);
+
+        metatomic_torch::register_autograd_neighbors(system, neighbors, false);
+        system->add_neighbor_list(request, neighbors);
+    }
+
+    // Pairlist DD mode: all atoms contribute to energy (each pair on one rank).
+    // Serial mode: same.
+    evaluationOptions_->set_selected_atoms(torch::nullopt);
+
+    // Forward pass
+    metatensor_torch::TensorMap outputMap;
+    try
+    {
+        std::vector<metatomic_torch::System> systems;
+        systems.push_back(system);
+
+        auto ivalueOutput = model_.forward({ systems, evaluationOptions_, false });
+        auto dictOutput   = ivalueOutput.toGenericDict();
+        outputMap = dictOutput.at("energy").toCustomClass<metatensor_torch::TensorMapHolder>();
+    }
+    catch (const std::exception& e)
+    {
+        GMX_THROW(APIError("[MetatomicGpu] Model evaluation failed: " + std::string(e.what())));
+    }
+
+    auto energyBlock  = metatensor_torch::TensorMapHolder::block_by_id(outputMap, 0);
+    auto energyTensor = energyBlock->values();
+
+    // Extract energy (always needed for logging/output)
+    cachedEnergy_ = energyTensor.sum().item<double>();
+
+    // Backward pass: compute forces via autograd
+    positions.mutable_grad() = torch::Tensor();
+    strain.mutable_grad()    = torch::Tensor();
+    energyTensor.backward(-torch::ones_like(energyTensor));
+
+    // Forces = position gradients (already negated by backward with -1)
+    auto forces = positions.grad(); // [modelNumAtoms, 3] on CUDA
+
+    // Extract virial from strain gradient (always needed)
+    auto virialTensor = strain.grad().to(torch::kCPU).to(torch::kFloat64);
+    auto virialAcc    = virialTensor.accessor<double, 2>();
+    for (int i = 0; i < 3; ++i)
+    {
+        for (int j = 0; j < 3; ++j)
+        {
+            cachedVirial_[i][j] = static_cast<real>(virialAcc[i][j]);
+        }
+    }
+
+    if (isDD_)
+    {
+        // DD mode: copy forces to CPU for distribution via MPI.
+        // Force tensor is on GPU; we need double precision on host.
+        auto forcesHost = forces.to(torch::kCPU).to(torch::kFloat64).contiguous();
+        cachedForcesHost_.resize(modelNumAtoms * 3);
+        std::memcpy(cachedForcesHost_.data(),
+                     forcesHost.data_ptr<double>(),
+                     modelNumAtoms * 3 * sizeof(double));
+    }
+    else
+    {
+        // Single-rank: copy forces to GPU DeviceBuffer for GpuForceReduction
+        auto forcesContig =
+                forces.to(std::is_same_v<real, double> ? torch::kFloat64 : torch::kFloat32)
+                        .contiguous();
+        cudaMemcpyAsync(forceBuffer_,
+                         forcesContig.data_ptr(),
+                         modelNumAtoms * sizeof(RVec),
+                         cudaMemcpyDeviceToDevice,
+                         deviceStream_.stream());
+
+        // Record completion event for GpuForceReduction
+        completionEvent_->markEvent(deviceStream_);
+    }
+}
+
+
+void MetatomicGpuForceProvider::Impl::distributeNonHomeForces(ForceWithVirial* forceWithVirial)
+{
+    GMX_RELEASE_ASSERT(isDD_, "distributeNonHomeForces called without DD");
+    GMX_RELEASE_ASSERT(!cachedForcesHost_.empty(), "No cached forces for DD distribution");
+
+    const int32_t numTotalGlobal = static_cast<int32_t>(globalAtomicNumbers_.size());
+    const double* forceData      = cachedForcesHost_.data();
+
+    // For small systems, dense allreduce has lower latency than sparse exchange
+    constexpr int32_t sparseThreshold = 1000;
+
+    if (numTotalGlobal < sparseThreshold)
+    {
+        // Dense fallback: allocate N_total buffer, scatter, allreduce, readback.
+        std::vector<double> denseForces(3 * numTotalGlobal, 0.0);
+        for (int32_t i = 0; i < numLocalMta_; i++)
+        {
+            int32_t g              = mtaToGlobalIdx_[i];
+            denseForces[3 * g]     = forceData[3 * i];
+            denseForces[3 * g + 1] = forceData[3 * i + 1];
+            denseForces[3 * g + 2] = forceData[3 * i + 2];
+        }
+        mpiComm_.sumReduce(static_cast<std::size_t>(3 * numTotalGlobal), denseForces.data());
+
+        for (int32_t i = 0; i < numHomeMta_; i++)
+        {
+            int32_t gmxIdx = mtaToGmxLocal_[i];
+            int32_t g      = mtaToGlobalIdx_[i];
+            forceWithVirial->force_[gmxIdx][0] += static_cast<real>(denseForces[3 * g]);
+            forceWithVirial->force_[gmxIdx][1] += static_cast<real>(denseForces[3 * g + 1]);
+            forceWithVirial->force_[gmxIdx][2] += static_cast<real>(denseForces[3 * g + 2]);
+        }
+        return;
+    }
+
+    // Sparse path: apply home forces directly, exchange only non-home forces.
+
+    // Step 1: Apply home atom forces directly
+    for (int32_t i = 0; i < numHomeMta_; i++)
+    {
+        int32_t gmxIdx = mtaToGmxLocal_[i];
+        forceWithVirial->force_[gmxIdx][0] += static_cast<real>(forceData[3 * i]);
+        forceWithVirial->force_[gmxIdx][1] += static_cast<real>(forceData[3 * i + 1]);
+        forceWithVirial->force_[gmxIdx][2] += static_cast<real>(forceData[3 * i + 2]);
+    }
+
+    // Step 2: Pack non-home forces as sparse tuples (globalIdx, fx, fy, fz)
+    const int32_t       numNonHome = numLocalMta_ - numHomeMta_;
+    std::vector<double> sendBuf(4 * numNonHome);
+    for (int32_t i = numHomeMta_; i < numLocalMta_; i++)
+    {
+        int32_t k      = i - numHomeMta_;
+        sendBuf[4 * k] = static_cast<double>(mtaToGlobalIdx_[i]);
+        sendBuf[4 * k + 1] = forceData[3 * i];
+        sendBuf[4 * k + 2] = forceData[3 * i + 1];
+        sendBuf[4 * k + 3] = forceData[3 * i + 2];
+    }
+
+    // Step 3: Exchange counts via allreduce
+    const int          numRanks = mpiComm_.size();
+    std::vector<int>   counts(numRanks, 0);
+    counts[mpiComm_.rank()] = numNonHome;
+    mpiComm_.sumReduce(ArrayRef<int>(counts));
+
+    // Step 4: Allgatherv via Gatherv + Bcast (thread-MPI compatible)
+    int              totalNonHome = 0;
+    std::vector<int> displs(numRanks);
+    for (int r = 0; r < numRanks; r++)
+    {
+        displs[r] = totalNonHome;
+        totalNonHome += counts[r];
+    }
+
+    std::vector<int> dcounts(numRanks), ddispls(numRanks);
+    for (int r = 0; r < numRanks; r++)
+    {
+        dcounts[r] = 4 * counts[r];
+        ddispls[r] = 4 * displs[r];
+    }
+
+    std::vector<double> recvBuf(4 * totalNonHome);
+    MPI_Gatherv(sendBuf.data(),
+                4 * numNonHome,
+                MPI_DOUBLE,
+                recvBuf.data(),
+                dcounts.data(),
+                ddispls.data(),
+                MPI_DOUBLE,
+                mpiComm_.mainRank(),
+                mpiComm_.comm());
+    MPI_Bcast(recvBuf.data(), 4 * totalNonHome, MPI_DOUBLE, mpiComm_.mainRank(), mpiComm_.comm());
+
+    // Step 5: Scan received tuples for forces destined for our home atoms
+    for (int t = 0; t < totalNonHome; t++)
+    {
+        int32_t globalIdx = static_cast<int32_t>(recvBuf[4 * t]);
+        auto    it        = globalIdxToLocalHome_.find(globalIdx);
+        if (it != globalIdxToLocalHome_.end())
+        {
+            int32_t localHomeIdx = it->second;
+            int32_t gmxIdx       = mtaToGmxLocal_[localHomeIdx];
+            forceWithVirial->force_[gmxIdx][0] += static_cast<real>(recvBuf[4 * t + 1]);
+            forceWithVirial->force_[gmxIdx][1] += static_cast<real>(recvBuf[4 * t + 2]);
+            forceWithVirial->force_[gmxIdx][2] += static_cast<real>(recvBuf[4 * t + 3]);
+        }
+    }
+}
+
+
+void MetatomicGpuForceProvider::Impl::applyOutputs(gmx_enerdata_t*  enerd,
+                                                     ForceWithVirial* forceWithVirial)
+{
+    // Energy: per-rank contribution (GROMACS global_stat sums across ranks)
+    enerd->term[InteractionFunction::MetatomicPotentialEnergy] = static_cast<real>(cachedEnergy_);
+
+    // Virial: per-rank contribution
+    forceWithVirial->addVirialContribution(cachedVirial_);
+
+    // DD: distribute forces via CPU
+    if (isDD_)
+    {
+        distributeNonHomeForces(forceWithVirial);
+    }
+}
+
+
+// ---- Public API forwarding to Impl ----
+
+MetatomicGpuForceProvider::MetatomicGpuForceProvider(const MetatomicParameters& params,
+                                                       const MDLogger&            logger,
+                                                       const DeviceContext&       deviceContext,
+                                                       const DeviceStream&        deviceStream,
+                                                       const MpiComm&             mpiComm,
+                                                       std::vector<int>           globalAtomicNumbers) :
+    impl_(std::make_unique<Impl>(params,
+                                  logger,
+                                  deviceContext,
+                                  deviceStream,
+                                  mpiComm,
+                                  std::move(globalAtomicNumbers)))
+{
+}
+
+MetatomicGpuForceProvider::~MetatomicGpuForceProvider() = default;
+
+void MetatomicGpuForceProvider::calculateForces(DeviceBuffer<RVec>    d_x,
+                                                 int                   numAtoms,
+                                                 const matrix          box,
+                                                 int64_t               step,
+                                                 const GpuPairlist*    gpuPairlist,
+                                                 DeviceBuffer<int>     d_atomIndex,
+                                                 const NBAtomDataGpu*  nbAtomData,
+                                                 bool                  isNsStep)
+{
+    impl_->calculateForces(d_x, numAtoms, box, step, gpuPairlist, d_atomIndex, nbAtomData, isNsStep);
+}
+
+void MetatomicGpuForceProvider::updateAtomMapping(int        numHomeAtoms,
+                                                    int        numTotalAtoms,
+                                                    const int* globalAtomIndices)
+{
+    impl_->updateAtomMapping(numHomeAtoms, numTotalAtoms, globalAtomIndices);
+}
+
+void MetatomicGpuForceProvider::applyOutputs(gmx_enerdata_t* enerd, ForceWithVirial* forceWithVirial)
+{
+    impl_->applyOutputs(enerd, forceWithVirial);
+}
+
+DeviceBuffer<RVec> MetatomicGpuForceProvider::getForceDeviceBuffer()
+{
+    return impl_->getForceDeviceBuffer();
+}
+
+GpuEventSynchronizer* MetatomicGpuForceProvider::getCompletionEvent()
+{
+    return impl_->getCompletionEvent();
+}
+
+bool MetatomicGpuForceProvider::hasDomainDecomposition() const
+{
+    return impl_->hasDomainDecomposition();
+}
+
+} // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.cpp
@@ -636,10 +636,14 @@ void MetatomicGpuForceProvider::Impl::calculateForces(DeviceBuffer<RVec>    d_x,
             continue;
         }
 
+        // Detach from any previous step's computational graph
+        auto samples   = nlSamples_.detach();
+        auto distances = nlDistances_.detach();
+
         auto neighborSamples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
-                nlSampleNames_, nlSamples_);
+                nlSampleNames_, samples);
         auto neighbors = torch::make_intrusive<metatensor_torch::TensorBlockHolder>(
-                nlDistances_,
+                distances,
                 neighborSamples,
                 std::vector<metatensor_torch::Labels>{ cachedNLComponent_ },
                 cachedNLProperties_);

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h
@@ -1,0 +1,180 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Declares the GPU-resident Metatomic Force Provider.
+ *
+ * This is a pure-ML GPU path that bypasses the IForceProvider interface.
+ * Coordinates are read directly from StatePropagatorDataGpu (zero-copy via
+ * torch::from_blob), neighbor lists are built on-device from the nbnxm
+ * GpuPairlist, and forces are written to a GPU DeviceBuffer registered with
+ * GpuForceReduction.  No GPU-CPU copies in the hot path (single-rank).
+ *
+ * Domain decomposition is supported via the "pairlist" mode: each pair is
+ * assigned to exactly one rank by the nbnxm DD decomposition, and halo
+ * forces are redistributed via sparse MPI exchange (same pattern as the
+ * CPU MetatomicForceProvider).
+ *
+ * \ingroup module_applied_forces
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "gromacs/gpu_utils/devicebuffer_datatype.h"
+#include "gromacs/utility/vectypes.h"
+
+class DeviceContext;
+class DeviceStream;
+class GpuEventSynchronizer;
+struct gmx_enerdata_t;
+
+namespace gmx
+{
+class GpuPairlist;
+class MpiComm;
+struct NBAtomDataGpu;
+struct MetatomicData;
+struct MetatomicParameters;
+class ForceWithVirial;
+class MDLogger;
+
+/*! \brief GPU-resident metatomic force provider (pure-ML, no ML/MM).
+ *
+ * Computes ALL forces from the metatomic model on GPU.
+ * Follows the PME GPU integration pattern: provides a DeviceBuffer<RVec>
+ * and a GpuEventSynchronizer for registration with GpuForceReduction.
+ *
+ * ## Domain decomposition
+ *
+ * When DD is active, forces are copied back to the CPU for sparse MPI
+ * exchange (home forces applied directly to ForceWithVirial, halo forces
+ * redistributed to their home ranks). Energy and virial are always
+ * extracted to the CPU for proper global statistics.
+ */
+class MetatomicGpuForceProvider
+{
+public:
+    /*! \brief Construct GPU metatomic force provider.
+     *
+     * \param[in] params               Model parameters (path, device, variant, nlMode)
+     * \param[in] logger               Logger for status messages
+     * \param[in] deviceContext         GPU device context
+     * \param[in] deviceStream          GPU stream for kernels
+     * \param[in] mpiComm              MPI communicator (serial or parallel)
+     * \param[in] globalAtomicNumbers  Atomic number for each global atom index
+     */
+    MetatomicGpuForceProvider(const MetatomicParameters& params,
+                              const MDLogger&            logger,
+                              const DeviceContext&       deviceContext,
+                              const DeviceStream&        deviceStream,
+                              const MpiComm&             mpiComm,
+                              std::vector<int>           globalAtomicNumbers);
+    ~MetatomicGpuForceProvider();
+
+    /*! \brief Evaluate model on GPU. Called each step from do_force().
+     *
+     * 1. Wraps GPU coordinates as torch tensor (zero-copy)
+     * 2. Builds NL on GPU from nbnxm GpuPairlist (NS steps only)
+     * 3. Runs model forward + backward pass
+     * 4. Single-rank: copies forces to forceBuffer_ (GpuForceReduction)
+     *    DD: copies forces to host buffer for later distribution
+     * 5. Extracts energy and virial to host
+     * 6. Records completion event (single-rank only)
+     *
+     * \param[in] d_x           Device coordinates in natural order
+     * \param[in] numAtoms      Number of atoms (home only in DD, total in serial)
+     * \param[in] box           Simulation box
+     * \param[in] step          Current MD step
+     * \param[in] gpuPairlist   nbnxm GPU pairlist (local)
+     * \param[in] d_atomIndex   nbnxm->natural atom index mapping
+     * \param[in] nbAtomData    nbnxm GPU atom data (xq, shiftVec for NL kernel)
+     * \param[in] isNsStep      Whether this is a neighbor-search step
+     */
+    void calculateForces(DeviceBuffer<RVec>    d_x,
+                         int                   numAtoms,
+                         const matrix          box,
+                         int64_t               step,
+                         const GpuPairlist*    gpuPairlist,
+                         DeviceBuffer<int>     d_atomIndex,
+                         const NBAtomDataGpu*  nbAtomData,
+                         bool                  isNsStep);
+
+    /*! \brief Update atom types and home/halo mapping after DD redistribution.
+     *
+     * Must be called before calculateForces() on each NS step.
+     * For serial runs, called once with identity mapping.
+     *
+     * \param[in] numHomeAtoms        Number of home atoms on this rank
+     * \param[in] numTotalAtoms       Total local atoms (home + halo)
+     * \param[in] globalAtomIndices   Global atom index for each local atom [numTotalAtoms]
+     *                                Use nullptr for serial (identity mapping, numHome == numTotal)
+     */
+    void updateAtomMapping(int numHomeAtoms, int numTotalAtoms, const int* globalAtomIndices);
+
+    /*! \brief Apply cached energy, virial, and (DD) forces to output structures.
+     *
+     * Must be called after calculateForces(), once ForceWithVirial is available.
+     * For single-rank: writes energy and virial only (forces via GpuForceReduction).
+     * For DD: also distributes forces (home -> ForceWithVirial, halo -> sparse MPI exchange).
+     *
+     * \param[in,out] enerd            Energy data (metatomic term written)
+     * \param[in,out] forceWithVirial  Force buffer for virial contribution + DD force application
+     */
+    void applyOutputs(gmx_enerdata_t* enerd, ForceWithVirial* forceWithVirial);
+
+    //! GPU force buffer in natural order — register with GpuForceReduction.
+    DeviceBuffer<RVec> getForceDeviceBuffer();
+
+    //! Sync event marking force computation complete.
+    GpuEventSynchronizer* getCompletionEvent();
+
+    //! Whether domain decomposition is active (affects force output path).
+    bool hasDomainDecomposition() const;
+
+private:
+    //! Build NL on GPU from nbnxm GpuPairlist (called on NS steps).
+    void buildNeighborListGpu(const GpuPairlist*   gpuPairlist,
+                              DeviceBuffer<int>    d_atomIndex,
+                              const NBAtomDataGpu* nbAtomData,
+                              int                  numAtoms,
+                              const matrix         box);
+
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h
@@ -90,7 +90,7 @@ class MetatomicGpuForceProvider
 public:
     /*! \brief Construct GPU metatomic force provider.
      *
-     * \param[in] params               Model parameters (path, device, variant, nlMode)
+     * \param[in] params               Model parameters (path, device, variant)
      * \param[in] logger               Logger for status messages
      * \param[in] deviceContext         GPU device context
      * \param[in] deviceStream          GPU stream for kernels

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h
@@ -123,6 +123,7 @@ public:
      * \param[in] d_atomIndex   nbnxm->natural atom index mapping
      * \param[in] nbAtomData    nbnxm GPU atom data (xq, shiftVec for NL kernel)
      * \param[in] isNsStep      Whether this is a neighbor-search step
+     * \param[in] xReadyOnDevice Event signaling coordinates are ready on GPU (consumed here)
      */
     void calculateForces(DeviceBuffer<RVec>    d_x,
                          int                   numAtoms,
@@ -131,7 +132,8 @@ public:
                          const GpuPairlist*    gpuPairlist,
                          DeviceBuffer<int>     d_atomIndex,
                          const NBAtomDataGpu*  nbAtomData,
-                         bool                  isNsStep);
+                         bool                  isNsStep,
+                         GpuEventSynchronizer* xReadyOnDevice);
 
     /*! \brief Update atom types and home/halo mapping after DD redistribution.
      *

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider_stub.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider_stub.cpp
@@ -76,7 +76,8 @@ void MetatomicGpuForceProvider::calculateForces(DeviceBuffer<RVec> /*d_x*/,
                                                 const GpuPairlist* /*gpuPairlist*/,
                                                 DeviceBuffer<int> /*d_atomIndex*/,
                                                 const NBAtomDataGpu* /*nbAtomData*/,
-                                                bool /*isNsStep*/)
+                                                bool /*isNsStep*/,
+                                                GpuEventSynchronizer* /*xReadyOnDevice*/)
 {
 }
 

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider_stub.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider_stub.cpp
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Stub implementation of the GPU Metatomic Force Provider.
+ * Compiled when CUDA is not available. All methods throw InternalError.
+ *
+ * \ingroup module_applied_forces
+ */
+#include "gmxpre.h"
+
+#include "metatomic_gpu_forceprovider.h"
+
+#include "gromacs/utility/basedefinitions.h"
+#include "gromacs/utility/exceptions.h"
+
+struct gmx_enerdata_t;
+
+namespace gmx
+{
+
+// Empty Impl definition so unique_ptr<Impl> destructor compiles in the stub.
+class MetatomicGpuForceProvider::Impl {};
+
+CLANG_DIAGNOSTIC_IGNORE("-Wmissing-noreturn")
+
+MetatomicGpuForceProvider::MetatomicGpuForceProvider(const MetatomicParameters& /*params*/,
+                                                     const MDLogger& /*logger*/,
+                                                     const DeviceContext& /*deviceContext*/,
+                                                     const DeviceStream& /*deviceStream*/,
+                                                     const MpiComm& /*mpiComm*/,
+                                                     std::vector<int> /*globalAtomicNumbers*/)
+{
+    GMX_THROW(InternalError(
+            "GPU metatomic force provider requires a CUDA build. "
+            "Please reconfigure with -DGMX_GPU=CUDA."));
+}
+
+MetatomicGpuForceProvider::~MetatomicGpuForceProvider() = default;
+
+void MetatomicGpuForceProvider::calculateForces(DeviceBuffer<RVec> /*d_x*/,
+                                                int /*numAtoms*/,
+                                                const matrix /*box*/,
+                                                int64_t /*step*/,
+                                                const GpuPairlist* /*gpuPairlist*/,
+                                                DeviceBuffer<int> /*d_atomIndex*/,
+                                                const NBAtomDataGpu* /*nbAtomData*/,
+                                                bool /*isNsStep*/)
+{
+}
+
+void MetatomicGpuForceProvider::updateAtomMapping(int /*numHomeAtoms*/,
+                                                  int /*numTotalAtoms*/,
+                                                  const int* /*globalAtomIndices*/)
+{
+}
+
+void MetatomicGpuForceProvider::applyOutputs(gmx_enerdata_t* /*enerd*/,
+                                             ForceWithVirial* /*forceWithVirial*/)
+{
+}
+
+DeviceBuffer<RVec> MetatomicGpuForceProvider::getForceDeviceBuffer()
+{
+    return nullptr;
+}
+
+GpuEventSynchronizer* MetatomicGpuForceProvider::getCompletionEvent()
+{
+    return nullptr;
+}
+
+bool MetatomicGpuForceProvider::hasDomainDecomposition() const
+{
+    return false;
+}
+
+CLANG_DIAGNOSTIC_RESET
+
+} // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -54,6 +54,7 @@
 #include "gromacs/mdrunutility/mdmodulesnotifiers.h"
 #include "gromacs/mdrunutility/plainpairlistranges.h"
 #include "gromacs/mdtypes/imdmodule.h"
+#include "gromacs/mdtypes/imdpoptionprovider_helpers.h"
 #include "gromacs/options/basicoptions.h"
 #include "gromacs/options/optionsection.h"
 #include "gromacs/utility/basenetwork.h"
@@ -100,11 +101,17 @@ public:
 
     void buildMdpOutput(KeyValueTreeObjectBuilder* builder) const override
     {
-        auto section = builder->addObject("metatomic-gpu");
-        section.addValue<bool>("active", active_);
-        section.addValue<std::string>("model-path", modelPath_);
-        section.addValue<std::string>("extensions-directory", extensionsDir_);
-        section.addValue<std::string>("variant", variant_);
+        addMdpOutputComment(builder, "metatomic-gpu", "empty-line", "");
+        addMdpOutputComment(
+                builder, "metatomic-gpu", "module", "; GPU-resident ML potential using metatomic");
+        addMdpOutputValue(builder, "metatomic-gpu", "active", active_);
+        if (active_)
+        {
+            addMdpOutputValue<std::string>(builder, "metatomic-gpu", "model-path", modelPath_);
+            addMdpOutputValue<std::string>(
+                    builder, "metatomic-gpu", "extensions-directory", extensionsDir_);
+            addMdpOutputValue<std::string>(builder, "metatomic-gpu", "variant", variant_);
+        }
     }
 
     bool        active() const { return active_; }

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -219,9 +219,6 @@ public:
                     ranges->addRange(maxCutoff);
                 });
 
-        // Flag this simulation as using a direct force provider (not IForceProvider)
-        notifiers->simulationSetupNotifier_.subscribe(
-                [](MDModulesDirectProvider* provider) { provider->isDirectProvider = true; });
     }
 
     void subscribeToSimulationRunNotifications(MDModulesNotifiers* /*notifiers*/) override

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -49,20 +49,26 @@
 #include <cmath>
 #include <cstdlib>
 
+#include <set>
 #include <string>
 
+#include "gromacs/domdec/localatomset.h"
+#include "gromacs/fileio/warninp.h"
 #include "gromacs/mdrunutility/mdmodulesnotifiers.h"
 #include "gromacs/mdrunutility/plainpairlistranges.h"
 #include "gromacs/mdtypes/imdmodule.h"
 #include "gromacs/mdtypes/imdpoptionprovider_helpers.h"
 #include "gromacs/options/basicoptions.h"
 #include "gromacs/options/optionsection.h"
+#include "gromacs/selection/indexutil.h"
+#include "gromacs/topology/embedded_system_preprocessing.h"
+#include "gromacs/topology/topology.h"
 #include "gromacs/utility/basenetwork.h"
 #include "gromacs/utility/exceptions.h"
 #include "gromacs/utility/keyvaluetreebuilder.h"
 #include "gromacs/utility/logger.h"
 #include "gromacs/utility/strconvert.h"
-#include "gromacs/domdec/localatomset.h"
+#include "gromacs/utility/stringutil.h"
 
 #include "metatomic_options.h"
 
@@ -82,9 +88,9 @@ namespace
 /*! \internal
  * \brief MDP option provider for the metatomic-gpu section.
  *
- * Lightweight: only stores the "active" flag and model path.
- * Shares the model path key with the CPU metatomic module to allow
- * both to coexist in the same MDP file.
+ * Handles MDP parsing, topology preprocessing (NB exclusions for ML atoms),
+ * and parameter storage. Shares the embedded-system preprocessing logic
+ * with the CPU metatomic module.
  */
 class MetatomicGpuOptions final : public IMdpOptionProvider
 {
@@ -99,6 +105,8 @@ public:
                 rules, stringIdentityTransform, "metatomic-gpu", "extensions-directory");
         addMdpTransformFromString<std::string>(
                 rules, stringIdentityTransform, "metatomic-gpu", "variant");
+        addMdpTransformFromString<std::string>(
+                rules, stringIdentityTransform, "metatomic-gpu", "input-group");
     }
 
     void initMdpOptions(IOptionsContainerWithSections* options) override
@@ -108,6 +116,7 @@ public:
         section.addOption(StringOption("model-path").store(&modelPath_));
         section.addOption(StringOption("extensions-directory").store(&extensionsDir_));
         section.addOption(StringOption("variant").store(&variant_));
+        section.addOption(StringOption("input-group").store(&inputGroup_));
     }
 
     void buildMdpOutput(KeyValueTreeObjectBuilder* builder) const override
@@ -122,6 +131,7 @@ public:
             addMdpOutputValue<std::string>(
                     builder, "metatomic-gpu", "extensions-directory", extensionsDir_);
             addMdpOutputValue<std::string>(builder, "metatomic-gpu", "variant", variant_);
+            addMdpOutputValue<std::string>(builder, "metatomic-gpu", "input-group", inputGroup_);
         }
     }
 
@@ -129,6 +139,56 @@ public:
     std::string modelPath() const { return modelPath_; }
     std::string extensionsDir() const { return extensionsDir_; }
     std::string variant() const { return variant_; }
+
+    //! Resolve input-group name to atom indices from index file
+    void setInputGroupIndices(const IndexGroupsAndNames& indexGroupsAndNames)
+    {
+        mtaIndices_ = indexGroupsAndNames.indices(inputGroup_);
+        if (mtaIndices_.empty())
+        {
+            GMX_THROW(InconsistentInputError(formatString(
+                    "Group '%s' defining metatomic-gpu input atoms should not be empty.",
+                    inputGroup_.c_str())));
+        }
+    }
+
+    //! Modify topology: exclude classical NB for ML atoms, remove bonded interactions
+    void modifyTopology(gmx_mtop_t* mtop)
+    {
+        std::set<int> mtaIndicesSet(mtaIndices_.begin(), mtaIndices_.end());
+        int           numMTAAtoms     = static_cast<int>(mtaIndices_.size());
+        int           numRegularAtoms = mtop->natoms - numMTAAtoms;
+
+        GMX_LOG(logger().info)
+                .appendText("Metatomic GPU potential interface is active, topology was modified!");
+        GMX_LOG(logger().info)
+                .appendTextFormatted(
+                        "Number of embedded Metatomic-GPU atoms: %d\nNumber of regular atoms: %d\n",
+                        numMTAAtoms,
+                        numRegularAtoms);
+
+        std::vector<bool> isMTABlock = splitEmbeddedBlocks(mtop, mtaIndicesSet);
+        addEmbeddedNBExclusions(mtop, mtaIndicesSet, logger());
+        buildEmbeddedAtomNumbers(*mtop);
+        modifyEmbeddedTwoCenterInteractions(mtop, mtaIndicesSet, isMTABlock, logger());
+        modifyEmbeddedThreeCenterInteractions(mtop, mtaIndicesSet, isMTABlock, logger());
+        modifyEmbeddedFourCenterInteractions(mtop, mtaIndicesSet, isMTABlock, logger());
+        checkConstrainedBonds(mtop, mtaIndicesSet, isMTABlock, wi_);
+        mtop->finalize();
+    }
+
+    void setLogger(const MDLogger& logger) { logger_ = &logger; }
+    void setWarningHandler(WarningHandler* wi) { wi_ = wi; }
+
+    //! Write input-group indices to KVT for .tpr storage
+    void writeInputGroupToKvt(KeyValueTreeObjectBuilder kvt)
+    {
+        auto indexAdder = kvt.addUniformArray<std::int64_t>("metatomic-gpu-input-group");
+        for (const auto& idx : mtaIndices_)
+        {
+            indexAdder.addValue(idx);
+        }
+    }
 
     //! Build a MetatomicParameters struct for the GPU provider
     MetatomicParameters buildParams() const
@@ -139,15 +199,26 @@ public:
         params.extensionsDirectory = extensionsDir_;
         params.variant             = variant_;
         params.device              = "cuda";
-        params.nlMode              = "full"; // GPU path doesn't use DD NL modes
+        params.nlMode              = "full";
+        params.inputGroup          = inputGroup_;
         return params;
     }
 
 private:
-    bool        active_        = false;
-    std::string modelPath_;
-    std::string extensionsDir_;
-    std::string variant_;
+    const MDLogger& logger() const
+    {
+        GMX_RELEASE_ASSERT(logger_, "Logger not set for MetatomicGpuOptions.");
+        return *logger_;
+    }
+
+    bool                active_     = false;
+    std::string         modelPath_;
+    std::string         extensionsDir_;
+    std::string         variant_;
+    std::string         inputGroup_ = "System";
+    std::vector<Index>  mtaIndices_;
+    const MDLogger*     logger_     = nullptr;
+    WarningHandler*     wi_         = nullptr;
 };
 
 
@@ -170,7 +241,23 @@ public:
             return;
         }
 
-        // Write GPU metatomic params to KVT for storage in .tpr
+        // Receive logger for topology modification messages
+        notifiers->preProcessingNotifier_.subscribe(
+                [this](const MDLogger& logger) { options_.setLogger(logger); });
+
+        // Receive warning handler for constraint checks
+        notifiers->preProcessingNotifier_.subscribe(
+                [this](WarningHandler* wi) { options_.setWarningHandler(wi); });
+
+        // Resolve input-group name to atom indices
+        notifiers->preProcessingNotifier_.subscribe(
+                [this](const IndexGroupsAndNames& idx) { options_.setInputGroupIndices(idx); });
+
+        // Modify topology: exclude classical NB for ML atoms
+        notifiers->preProcessingNotifier_.subscribe(
+                [this](gmx_mtop_t* top) { options_.modifyTopology(top); });
+
+        // Write GPU metatomic params + input-group indices to KVT for .tpr
         notifiers->preProcessingNotifier_.subscribe(
                 [this](KeyValueTreeObjectBuilder kvt)
                 {
@@ -179,6 +266,7 @@ public:
                     section.addValue<std::string>("model-path", options_.modelPath());
                     section.addValue<std::string>("extensions-directory", options_.extensionsDir());
                     section.addValue<std::string>("variant", options_.variant());
+                    options_.writeInputGroupToKvt(kvt);
                 });
     }
 
@@ -237,6 +325,10 @@ public:
                     ranges->addRange(maxCutoff);
                 });
 
+        // Request "Metatomic Potential" energy term in .edr output
+        notifiers->simulationSetupNotifier_.subscribe(
+                [](MDModulesEnergyOutputToMetatomicPotRequestChecker* req)
+                { req->energyOutputToMetatomicPot_ = true; });
     }
 
     void subscribeToSimulationRunNotifications(MDModulesNotifiers* /*notifiers*/) override

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -61,6 +61,7 @@
 #include "gromacs/utility/exceptions.h"
 #include "gromacs/utility/keyvaluetreebuilder.h"
 #include "gromacs/utility/logger.h"
+#include "gromacs/utility/strconvert.h"
 #include "gromacs/domdec/localatomset.h"
 
 #include "metatomic_options.h"
@@ -88,7 +89,17 @@ namespace
 class MetatomicGpuOptions final : public IMdpOptionProvider
 {
 public:
-    void initMdpTransform(IKeyValueTreeTransformRules* /*rules*/) override {}
+    void initMdpTransform(IKeyValueTreeTransformRules* rules) override
+    {
+        const auto& stringIdentityTransform = [](std::string s) { return s; };
+        addMdpTransformFromString<bool>(rules, &fromStdString<bool>, "metatomic-gpu", "active");
+        addMdpTransformFromString<std::string>(
+                rules, stringIdentityTransform, "metatomic-gpu", "model-path");
+        addMdpTransformFromString<std::string>(
+                rules, stringIdentityTransform, "metatomic-gpu", "extensions-directory");
+        addMdpTransformFromString<std::string>(
+                rules, stringIdentityTransform, "metatomic-gpu", "variant");
+    }
 
     void initMdpOptions(IOptionsContainerWithSections* options) override
     {

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -199,7 +199,6 @@ public:
         params.extensionsDirectory = extensionsDir_;
         params.variant             = variant_;
         params.device              = "cuda";
-        params.nlMode              = "full";
         params.inputGroup          = inputGroup_;
         return params;
     }

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -289,11 +289,15 @@ public:
                     }
                 });
 
-        // Register model cutoff for pairlist range (same pattern as CPU module)
+        // Register model cutoff for pairlist range.
+        // For Newton mode DD, the registered range must be
+        // interaction_range + max_nl_cutoff so that halo atoms have
+        // complete neighbor lists within the DD communication zone.
         notifiers->simulationSetupNotifier_.subscribe(
                 [this](PlainPairlistRanges* ranges)
                 {
-                    double maxCutoff = 0.0;
+                    double interactionRange = 0.0;
+                    double maxNlCutoff      = 0.0;
                     try
                     {
                         auto model = metatomic_torch::load_atomistic_model(options_.modelPath());
@@ -302,13 +306,13 @@ public:
                         double range = caps->engine_interaction_range("nm");
                         if (range > 0.0 && std::isfinite(range))
                         {
-                            maxCutoff = range;
+                            interactionRange = range;
                         }
                         auto nlRequests = model.run_method("requested_neighbor_lists");
                         for (const auto& req : nlRequests.toList())
                         {
                             auto nlOpt = req.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
-                            maxCutoff  = std::max(maxCutoff, nlOpt->engine_cutoff("nm"));
+                            maxNlCutoff = std::max(maxNlCutoff, nlOpt->engine_cutoff("nm"));
                         }
                     }
                     catch (const std::exception& e)
@@ -317,12 +321,17 @@ public:
                                 "Failed to read cutoff from GPU metatomic model: " + std::string(e.what())));
                     }
 
-                    if (maxCutoff <= 0.0 || !std::isfinite(maxCutoff))
+                    // Use the sum: halo atoms at distance interaction_range
+                    // from a home atom must themselves have complete NLs
+                    // (cutoff radius maxNlCutoff). For single-rank this is
+                    // conservative but harmless.
+                    double totalRange = interactionRange + maxNlCutoff;
+                    if (totalRange <= 0.0 || !std::isfinite(totalRange))
                     {
                         GMX_THROW(InconsistentInputError(
                                 "Metatomic GPU model cutoff is invalid."));
                     }
-                    ranges->addRange(maxCutoff);
+                    ranges->addRange(totalRange);
                 });
 
         // Request "Metatomic Potential" energy term in .edr output

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.cpp
@@ -1,0 +1,253 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements the GPU-resident Metatomic MDModule.
+ *
+ * This module handles MDP option parsing for the `metatomic-gpu` section,
+ * registers the model cutoff with the pairlist range system, and provides
+ * the MetatomicParameters for runner.cpp to create the GPU force provider.
+ * Unlike the CPU MetatomicMDModule, this does NOT register an IForceProvider.
+ *
+ * \ingroup module_applied_forces
+ */
+#include "gmxpre.h"
+
+#include "metatomic_gpu_mdmodule.h"
+
+#include <cmath>
+#include <cstdlib>
+
+#include <string>
+
+#include "gromacs/mdrunutility/mdmodulesnotifiers.h"
+#include "gromacs/mdrunutility/plainpairlistranges.h"
+#include "gromacs/mdtypes/imdmodule.h"
+#include "gromacs/options/basicoptions.h"
+#include "gromacs/options/optionsection.h"
+#include "gromacs/utility/basenetwork.h"
+#include "gromacs/utility/exceptions.h"
+#include "gromacs/utility/keyvaluetreebuilder.h"
+#include "gromacs/utility/logger.h"
+#include "gromacs/domdec/localatomset.h"
+
+#include "metatomic_options.h"
+
+#ifdef DIM
+#    undef DIM
+#endif
+
+#include <metatensor/torch.hpp>
+#include <metatomic/torch.hpp>
+
+namespace gmx
+{
+
+namespace
+{
+
+/*! \internal
+ * \brief MDP option provider for the metatomic-gpu section.
+ *
+ * Lightweight: only stores the "active" flag and model path.
+ * Shares the model path key with the CPU metatomic module to allow
+ * both to coexist in the same MDP file.
+ */
+class MetatomicGpuOptions final : public IMdpOptionProvider
+{
+public:
+    void initMdpTransform(IKeyValueTreeTransformRules* /*rules*/) override {}
+
+    void initMdpOptions(IOptionsContainerWithSections* options) override
+    {
+        auto section = options->addSection(OptionSection("metatomic-gpu"));
+        section.addOption(BooleanOption("active").store(&active_));
+        section.addOption(StringOption("model-path").store(&modelPath_));
+        section.addOption(StringOption("extensions-directory").store(&extensionsDir_));
+        section.addOption(StringOption("variant").store(&variant_));
+    }
+
+    void buildMdpOutput(KeyValueTreeObjectBuilder* builder) const override
+    {
+        auto section = builder->addObject("metatomic-gpu");
+        section.addValue<bool>("active", active_);
+        section.addValue<std::string>("model-path", modelPath_);
+        section.addValue<std::string>("extensions-directory", extensionsDir_);
+        section.addValue<std::string>("variant", variant_);
+    }
+
+    bool        active() const { return active_; }
+    std::string modelPath() const { return modelPath_; }
+    std::string extensionsDir() const { return extensionsDir_; }
+    std::string variant() const { return variant_; }
+
+    //! Build a MetatomicParameters struct for the GPU provider
+    MetatomicParameters buildParams() const
+    {
+        MetatomicParameters params;
+        params.active              = active_;
+        params.modelPath_          = modelPath_;
+        params.extensionsDirectory = extensionsDir_;
+        params.variant             = variant_;
+        params.device              = "cuda";
+        params.nlMode              = "full"; // GPU path doesn't use DD NL modes
+        return params;
+    }
+
+private:
+    bool        active_        = false;
+    std::string modelPath_;
+    std::string extensionsDir_;
+    std::string variant_;
+};
+
+
+/*! \internal
+ * \brief GPU Metatomic MDModule.
+ *
+ * Subscribes to PlainPairlistRanges to register the model cutoff.
+ * Does NOT register an IForceProvider — the GPU force provider is created
+ * directly in runner.cpp with the proper DeviceContext/DeviceStream.
+ */
+class MetatomicGpuMDModule final : public IMDModule
+{
+public:
+    explicit MetatomicGpuMDModule() = default;
+
+    void subscribeToPreProcessingNotifications(MDModulesNotifiers* notifiers) override
+    {
+        if (!options_.active())
+        {
+            return;
+        }
+
+        // Write GPU metatomic params to KVT for storage in .tpr
+        notifiers->preProcessingNotifier_.subscribe(
+                [this](KeyValueTreeObjectBuilder kvt)
+                {
+                    auto section = kvt.addObject("metatomic-gpu");
+                    section.addValue<bool>("active", options_.active());
+                    section.addValue<std::string>("model-path", options_.modelPath());
+                    section.addValue<std::string>("extensions-directory", options_.extensionsDir());
+                    section.addValue<std::string>("variant", options_.variant());
+                });
+    }
+
+    void subscribeToSimulationSetupNotifications(MDModulesNotifiers* notifiers) override
+    {
+        if (!options_.active())
+        {
+            return;
+        }
+
+        // Read params back from KVT (.tpr)
+        notifiers->simulationSetupNotifier_.subscribe(
+                [this](const KeyValueTreeObject& kvt)
+                {
+                    if (kvt.keyExists("metatomic-gpu"))
+                    {
+                        // Parameters already set from MDP; this block is
+                        // a placeholder for future .tpr restore logic.
+                        static_cast<void>(kvt["metatomic-gpu"]);
+                    }
+                });
+
+        // Register model cutoff for pairlist range (same pattern as CPU module)
+        notifiers->simulationSetupNotifier_.subscribe(
+                [this](PlainPairlistRanges* ranges)
+                {
+                    double maxCutoff = 0.0;
+                    try
+                    {
+                        auto model = metatomic_torch::load_atomistic_model(options_.modelPath());
+                        auto caps  = model.run_method("capabilities")
+                                             .toCustomClass<metatomic_torch::ModelCapabilitiesHolder>();
+                        double range = caps->engine_interaction_range("nm");
+                        if (range > 0.0 && std::isfinite(range))
+                        {
+                            maxCutoff = range;
+                        }
+                        auto nlRequests = model.run_method("requested_neighbor_lists");
+                        for (const auto& req : nlRequests.toList())
+                        {
+                            auto nlOpt = req.get().toCustomClass<metatomic_torch::NeighborListOptionsHolder>();
+                            maxCutoff  = std::max(maxCutoff, nlOpt->engine_cutoff("nm"));
+                        }
+                    }
+                    catch (const std::exception& e)
+                    {
+                        GMX_THROW(InternalError(
+                                "Failed to read cutoff from GPU metatomic model: " + std::string(e.what())));
+                    }
+
+                    if (maxCutoff <= 0.0 || !std::isfinite(maxCutoff))
+                    {
+                        GMX_THROW(InconsistentInputError(
+                                "Metatomic GPU model cutoff is invalid."));
+                    }
+                    ranges->addRange(maxCutoff);
+                });
+
+        // Flag this simulation as using a direct force provider (not IForceProvider)
+        notifiers->simulationSetupNotifier_.subscribe(
+                [](MDModulesDirectProvider* provider) { provider->isDirectProvider = true; });
+    }
+
+    void subscribeToSimulationRunNotifications(MDModulesNotifiers* /*notifiers*/) override
+    {
+        // GPU force provider handles atoms redistributed signal directly
+        // from runner.cpp, not through the MDModule notification system.
+    }
+
+    void initForceProviders(ForceProviders* /*forceProviders*/) override
+    {
+        // Intentionally empty: GPU force provider is NOT an IForceProvider.
+        // Created directly in runner.cpp with proper DeviceContext/DeviceStream.
+    }
+
+    IMdpOptionProvider* mdpOptionProvider() override { return &options_; }
+    IMDOutputProvider*  outputProvider() override { return nullptr; }
+
+private:
+    MetatomicGpuOptions options_;
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<IMDModule> MetatomicGpuModuleInfo::create()
+{
+    return std::make_unique<MetatomicGpuMDModule>();
+}
+
+} // end namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.h
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Declares factory structure for Metatomic GPU MDModule.
+ *
+ * \ingroup module_applied_forces
+ */
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+namespace gmx
+{
+
+class IMDModule;
+
+/*! \internal
+ * \brief Information about the GPU Metatomic module.
+ *
+ * Provides name and method to create a GPU-resident metatomic potential module.
+ * This module does NOT use IForceProvider; instead it exposes the GPU force
+ * provider parameters for runner.cpp to instantiate MetatomicGpuForceProvider.
+ */
+struct MetatomicGpuModuleInfo
+{
+    static std::unique_ptr<IMDModule> create();
+    static constexpr std::string_view sc_name = "metatomic-gpu";
+};
+
+} // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_pairlist_kernel.cu
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_pairlist_kernel.cu
@@ -1,0 +1,268 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief CUDA kernel converting nbnxm GpuPairlist to metatensor neighbor list format.
+ *
+ * Mirrors appendPlainPairlistGpu() (pairlistset.cpp) but runs entirely on device.
+ * One thread block per i-super-cluster; each thread handles one i-atom within
+ * the super-cluster and iterates over all j-clusters.
+ *
+ * \ingroup module_applied_forces
+ */
+#include "gmxpre.h"
+
+#include "metatomic_gpu_pairlist_kernel.cuh"
+
+#include "gromacs/nbnxm/nbnxm_enums.h"
+#include "gromacs/nbnxm/pairlist.h"
+
+namespace gmx
+{
+
+//! Number of i-atoms per super-cluster (= c_numClusterPerCell * c_clSize)
+static constexpr int c_superClusterSize =
+        sc_gpuNumClusterPerBin(sc_layoutType) * detail::c_nbnxnGpuClusterSize;
+
+//! Number of i-clusters per super-cluster
+static constexpr int c_numClusterPerCell = sc_gpuNumClusterPerBin(sc_layoutType);
+
+//! Cluster size
+static constexpr int c_clSize = detail::c_nbnxnGpuClusterSize;
+
+//! Number of j-clusters per packed j-group
+static constexpr int c_jGroupSize = sc_gpuJgroupSize(sc_layoutType);
+
+//! Split cluster size (for exclusion indexing)
+static constexpr int c_splitClusterSize =
+        detail::c_nbnxnGpuClusterSize / sc_gpuClusterPairSplit(sc_layoutType);
+
+//! Interaction mask for all i-clusters within a super-cluster
+static constexpr unsigned int c_superClInteractionMask = ((1U << c_numClusterPerCell) - 1U);
+
+//! Shift grid dimensions (from ishift.h: c_dBoxX=2, c_dBoxY=1, c_dBoxZ=1)
+static constexpr int c_nBoxX = 2 * c_dBoxX + 1;
+static constexpr int c_nBoxY = 2 * c_dBoxY + 1;
+
+/*! \brief Convert GROMACS shift index to metatensor cell shifts (negated).
+ *
+ * GROMACS convention: d_ij = x[i] + shift_vec - x[j]
+ * Metatensor convention: r_ij = x[j] + cell_shift*box - x[i]
+ * Therefore: metatensor cell_shift = -(GROMACS cell_shift)
+ */
+__device__ __forceinline__ void shiftIndexToNegCellShift(int shiftIndex,
+                                                         int& sa,
+                                                         int& sb,
+                                                         int& sc)
+{
+    const int divZ = shiftIndex / (c_nBoxY * c_nBoxX);
+    const int rem  = shiftIndex - divZ * (c_nBoxY * c_nBoxX);
+    const int divY = rem / c_nBoxX;
+    const int xPart = rem - divY * c_nBoxX;
+
+    // GROMACS shift = (xPart - c_dBoxX, divY - c_dBoxY, divZ - c_dBoxZ)
+    // Metatensor = negation
+    sa = -(xPart - c_dBoxX);
+    sb = -(divY - c_dBoxY);
+    sc = -(divZ - c_dBoxZ);
+}
+
+/*! \brief CUDA kernel: convert nbnxm GpuPairlist → metatensor NL format.
+ *
+ * Each thread block handles one i-super-cluster. Thread index maps to i-atom
+ * within the super-cluster (64 threads = 8 clusters × 8 atoms).
+ * For each i-atom, iterates over all j-packed groups and j-atoms, checks
+ * interaction mask + distance filter, and emits valid pairs to output buffers.
+ *
+ * Outputs ALL pairs within cutoff (including classically excluded pairs),
+ * since ML models need the full neighbor list.
+ *
+ * \param[in]  d_sci          i-super-cluster entries [numSci]
+ * \param[in]  d_cjPacked     Packed j-cluster groups
+ * \param[in]  d_excl         Exclusion masks (unused — we emit all pairs)
+ * \param[in]  d_atomIndex    nbnxm→natural atom index mapping
+ * \param[in]  d_xq           Atom positions+charge in nbnxm order [float4: x,y,z,q]
+ * \param[in]  d_shiftVec     Shift vectors [float3, c_numShiftVectors entries]
+ * \param[out] d_samples      Output: pair samples [capacity, 5] as (i, j, sa, sb, sc)
+ * \param[out] d_distances    Output: distance vectors [capacity, 3] as (dx, dy, dz)
+ * \param[out] d_count        Atomic counter for number of pairs written
+ * \param[in]  capacity       Max pairs before overflow
+ * \param[in]  cutoffSq       Squared cutoff distance
+ * \param[in]  numSci         Number of super-clusters
+ */
+__global__ void convertPairlistToMetatomicKernel(const nbnxn_sci_t*       d_sci,
+                                                  const nbnxn_cj_packed_t* d_cjPacked,
+                                                  const int*               d_atomIndex,
+                                                  const float4*            d_xq,
+                                                  const float3*            d_shiftVec,
+                                                  int32_t*                 d_samples,
+                                                  float*                   d_distances,
+                                                  int64_t*                 d_count,
+                                                  int64_t                  capacity,
+                                                  float                    cutoffSq,
+                                                  int                      numSci)
+{
+    const int sciIdx = blockIdx.x;
+    if (sciIdx >= numSci)
+    {
+        return;
+    }
+
+    const nbnxn_sci_t nbSci = d_sci[sciIdx];
+    const int         shift  = nbSci.shift;
+    const float3      sv     = d_shiftVec[shift];
+
+    // Thread index → i-atom within super-cluster
+    // tid ∈ [0, c_superClusterSize)  where c_superClusterSize = 64
+    const int tid          = threadIdx.x;
+    const int iClusterIdx  = tid / c_clSize;     // which i-cluster (0..7)
+    const int iInCluster   = tid % c_clSize;     // which atom within i-cluster (0..7)
+
+    // Global nbnxm index for this i-atom
+    const int iAtomNbnxm = nbSci.sci * c_superClusterSize + tid;
+    const int atomI      = d_atomIndex[iAtomNbnxm];
+
+    // Skip filler atoms
+    if (atomI < 0)
+    {
+        return;
+    }
+
+    // Load i-atom position (shifted)
+    const float4 xqI = d_xq[iAtomNbnxm];
+    const float  xiS = xqI.x + sv.x;
+    const float  yiS = xqI.y + sv.y;
+    const float  ziS = xqI.z + sv.z;
+
+    // Precompute cell shift for this super-cluster
+    int cellShiftA, cellShiftB, cellShiftC;
+    shiftIndexToNegCellShift(shift, cellShiftA, cellShiftB, cellShiftC);
+
+    // Central shift index for self-pair check
+    constexpr int centralShift = c_dBoxX + c_dBoxY * c_nBoxX + c_dBoxZ * c_nBoxY * c_nBoxX;
+
+    // Iterate over packed j-cluster groups
+    for (int jPackIdx = nbSci.cjPackedBegin; jPackIdx < nbSci.cjPackedEnd; jPackIdx++)
+    {
+        const nbnxn_cj_packed_t jPack = d_cjPacked[jPackIdx];
+
+        for (int jInPack = 0; jInPack < c_jGroupSize; jInPack++)
+        {
+            // Check if this j-cluster interacts with any i-cluster at all
+            if ((jPack.imei[0].imask & (c_superClInteractionMask << (jInPack * c_numClusterPerCell))) == 0)
+            {
+                continue;
+            }
+
+            // Check if this specific (i-cluster, j-cluster) pair interacts
+            const unsigned int clusterPairMask = 1U << (jInPack * c_numClusterPerCell + iClusterIdx);
+            if ((jPack.imei[0].imask & clusterPairMask) == 0)
+            {
+                continue;
+            }
+
+            const int jCluster = jPack.cj[jInPack];
+
+            // Iterate over j-atoms in this cluster
+            for (int j = 0; j < c_clSize; j++)
+            {
+                const int jAtomNbnxm = jCluster * c_clSize + j;
+                const int atomJ      = d_atomIndex[jAtomNbnxm];
+
+                if (atomJ < 0)
+                {
+                    continue; // filler
+                }
+
+                // Self-pair exclusion: same atom in central image
+                if (shift == centralShift && atomI == atomJ)
+                {
+                    continue;
+                }
+
+                // Compute distance (metatensor convention: r_ij = x[j] - x[i] - shift_vec)
+                const float4 xqJ = d_xq[jAtomNbnxm];
+                const float  dx  = xqJ.x - xiS;
+                const float  dy  = xqJ.y - yiS;
+                const float  dz  = xqJ.z - ziS;
+                const float  r2  = dx * dx + dy * dy + dz * dz;
+
+                if (r2 < cutoffSq)
+                {
+                    const int64_t idx = atomicAdd(reinterpret_cast<unsigned long long*>(d_count),
+                                                  static_cast<unsigned long long>(1));
+                    if (idx < capacity)
+                    {
+                        d_samples[idx * 5 + 0] = atomI;
+                        d_samples[idx * 5 + 1] = atomJ;
+                        d_samples[idx * 5 + 2] = cellShiftA;
+                        d_samples[idx * 5 + 3] = cellShiftB;
+                        d_samples[idx * 5 + 4] = cellShiftC;
+                        d_distances[idx * 3 + 0] = dx;
+                        d_distances[idx * 3 + 1] = dy;
+                        d_distances[idx * 3 + 2] = dz;
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+void launchConvertPairlistToMetatomicKernel(const nbnxn_sci_t*       d_sci,
+                                             const nbnxn_cj_packed_t* d_cjPacked,
+                                             const int*               d_atomIndex,
+                                             const float4*            d_xq,
+                                             const float3*            d_shiftVec,
+                                             int32_t*                 d_samples,
+                                             float*                   d_distances,
+                                             int64_t*                 d_count,
+                                             int64_t                  capacity,
+                                             float                    cutoffSq,
+                                             int                      numSci,
+                                             const DeviceStream&      deviceStream)
+{
+    if (numSci == 0)
+    {
+        return;
+    }
+
+    const int blockSize = c_superClusterSize; // 64 threads
+    const int numBlocks = numSci;
+
+    convertPairlistToMetatomicKernel<<<numBlocks, blockSize, 0, deviceStream.stream()>>>(
+            d_sci, d_cjPacked, d_atomIndex, d_xq, d_shiftVec,
+            d_samples, d_distances, d_count, capacity, cutoffSq, numSci);
+}
+
+} // namespace gmx

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_pairlist_kernel.cu
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_pairlist_kernel.cu
@@ -46,6 +46,7 @@
 
 #include "gromacs/nbnxm/nbnxm_enums.h"
 #include "gromacs/nbnxm/pairlist.h"
+#include "gromacs/pbcutil/ishift.h"
 
 namespace gmx
 {

--- a/src/gromacs/applied_forces/metatomic/metatomic_gpu_pairlist_kernel.cuh
+++ b/src/gromacs/applied_forces/metatomic/metatomic_gpu_pairlist_kernel.cuh
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2024- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief Declaration for the CUDA kernel converting nbnxm GpuPairlist
+ *        to metatensor neighbor list format.
+ *
+ * \ingroup module_applied_forces
+ */
+#ifndef GMX_APPLIED_FORCES_METATOMIC_GPU_PAIRLIST_KERNEL_CUH
+#define GMX_APPLIED_FORCES_METATOMIC_GPU_PAIRLIST_KERNEL_CUH
+
+#include <cstdint>
+
+#include "gromacs/gpu_utils/device_stream.h"
+
+struct nbnxn_sci_t;
+struct nbnxn_cj_packed_t;
+
+namespace gmx
+{
+
+/*! \brief Launch the CUDA kernel to convert nbnxm GPU pairlist to metatensor NL format.
+ *
+ * Iterates over the GpuPairlist's super-cluster entries on GPU, producing
+ * metatensor-format neighbor list tensors (samples + distances) directly in
+ * device memory.  All atom pairs within the cutoff are emitted, including
+ * classically excluded pairs (ML models need the full NL).
+ *
+ * If the output counter exceeds \p capacity, the caller should reallocate
+ * and relaunch.
+ *
+ * \param[in]  d_sci          i-super-cluster entries [numSci]
+ * \param[in]  d_cjPacked     Packed j-cluster groups
+ * \param[in]  d_atomIndex    nbnxm→natural atom index mapping
+ * \param[in]  d_xq           Atom positions+charge in nbnxm order [float4]
+ * \param[in]  d_shiftVec     Shift vectors [float3]
+ * \param[out] d_samples      Output: pair samples [capacity, 5] (i, j, sa, sb, sc) int32
+ * \param[out] d_distances    Output: distance vectors [capacity, 3] float
+ * \param[out] d_count        Atomic counter for written pairs (int64)
+ * \param[in]  capacity       Maximum number of pairs before overflow
+ * \param[in]  cutoffSq       Squared cutoff distance
+ * \param[in]  numSci         Number of i-super-clusters
+ * \param[in]  deviceStream   CUDA stream to launch on
+ */
+void launchConvertPairlistToMetatomicKernel(const nbnxn_sci_t*       d_sci,
+                                             const nbnxn_cj_packed_t* d_cjPacked,
+                                             const int*               d_atomIndex,
+                                             const float4*            d_xq,
+                                             const float3*            d_shiftVec,
+                                             int32_t*                 d_samples,
+                                             float*                   d_distances,
+                                             int64_t*                 d_count,
+                                             int64_t                  capacity,
+                                             float                    cutoffSq,
+                                             int                      numSci,
+                                             const DeviceStream&      deviceStream);
+
+} // namespace gmx
+
+#endif

--- a/src/gromacs/mdlib/forcerec.cpp
+++ b/src/gromacs/mdlib/forcerec.cpp
@@ -37,6 +37,8 @@
 
 #include "config.h"
 
+#include "gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h"
+
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>

--- a/src/gromacs/mdlib/sim_util.cpp
+++ b/src/gromacs/mdlib/sim_util.cpp
@@ -1074,6 +1074,11 @@ static int getExpectedLocalXReadyOnDeviceConsumptionCount(const SimulationWorklo
             result++;
         }
     }
+    if (simulationWork.useGpuMetatomic)
+    {
+        // Event is consumed by MetatomicGpuForceProvider::calculateForces
+        result++;
+    }
     return result;
 }
 
@@ -1642,7 +1647,8 @@ void do_force(FILE*                         fplog,
     }
 
     auto* localXReadyOnDevice = (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps
-                                 || simulationWork.useGpuUpdate || pmeSendCoordinatesFromGpu)
+                                 || simulationWork.useGpuUpdate || pmeSendCoordinatesFromGpu
+                                 || simulationWork.useGpuMetatomic)
                                         ? stateGpu->getCoordinatesReadyOnDeviceEvent(
                                                   AtomLocality::Local, simulationWork, stepWork)
                                         : nullptr;
@@ -1699,7 +1705,8 @@ void do_force(FILE*                         fplog,
     // The local coordinates can be copied right away.
     // NOTE: Consider moving this copy to right after they are updated and constrained,
     //       if the later is not offloaded.
-    if (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps || pmeSendCoordinatesFromGpu)
+    if (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps || pmeSendCoordinatesFromGpu
+        || simulationWork.useGpuMetatomic)
     {
         GMX_ASSERT(stateGpu != nullptr, "stateGpu should not be null");
         const int expectedLocalXReadyOnDeviceConsumptionCount =
@@ -1860,7 +1867,8 @@ void do_force(FILE*                         fplog,
                                            gpuPl,
                                            d_atomIdx,
                                            nbAtomData,
-                                           stepWork.doNeighborSearch);
+                                           stepWork.doNeighborSearch,
+                                           localXReadyOnDevice);
     }
 
     if (stepWork.haveGpuPmeOnThisRank)

--- a/src/gromacs/mdlib/sim_util.cpp
+++ b/src/gromacs/mdlib/sim_util.cpp
@@ -52,6 +52,7 @@
 #include <vector>
 
 #include "gromacs/applied_forces/awh/awh.h"
+#include "gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h"
 #include "gromacs/domdec/dlbtiming.h"
 #include "gromacs/domdec/domdec.h"
 #include "gromacs/domdec/domdec_struct.h"
@@ -1199,7 +1200,8 @@ static void setupLocalGpuForceReduction(const MdrunScheduleWorkload& runSchedule
                                         GpuForceReduction*           gpuForceReduction,
                                         PmePpCommGpu*                pmePpCommGpu,
                                         const gmx_pme_t*             pmedata,
-                                        const gmx_domdec_t*          dd)
+                                        const gmx_domdec_t*          dd,
+                                        const t_forcerec*            fr = nullptr)
 {
     GMX_ASSERT(!runScheduleWork.simulationWork.useMts,
                "GPU force reduction is not compatible with MTS");
@@ -1260,6 +1262,15 @@ static void setupLocalGpuForceReduction(const MdrunScheduleWorkload& runSchedule
             GMX_ASSERT(pmeSynchronizer != nullptr, "PME force ready cuda event should not be NULL");
             gpuForceReduction->addDependency(pmeSynchronizer);
         }
+    }
+
+    if (runScheduleWork.simulationWork.useGpuMetatomic && fr->metatomicGpu
+        && !fr->metatomicGpu->hasDomainDecomposition())
+    {
+        // Single-rank: forces stay on GPU via GpuForceReduction.
+        // DD mode: forces are distributed via CPU in applyOutputs().
+        gpuForceReduction->registerRvecForce(fr->metatomicGpu->getForceDeviceBuffer());
+        gpuForceReduction->addDependency(fr->metatomicGpu->getCompletionEvent());
     }
 
     if (runScheduleWork.domainWork.haveCpuLocalForceWork
@@ -1492,7 +1503,8 @@ static void doPairSearch(const t_commrec*             cr,
                                         fr->gpuForceReduction[AtomLocality::Local].get(),
                                         fr->pmePpCommGpu.get(),
                                         fr->pmedata,
-                                        cr->dd);
+                                        cr->dd,
+                                        fr);
         }
 
         if (simulationWork.havePpDomainDecomposition)
@@ -1750,7 +1762,8 @@ void do_force(FILE*                         fplog,
                                         fr->gpuForceReduction[AtomLocality::Local].get(),
                                         fr->pmePpCommGpu.get(),
                                         fr->pmedata,
-                                        cr->dd);
+                                        cr->dd,
+                                        fr);
         }
     }
 
@@ -1820,6 +1833,34 @@ void do_force(FILE*                         fplog,
         }
         wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
         wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    // GPU-resident metatomic: evaluate ML model on GPU
+    if (simulationWork.useGpuMetatomic && fr->metatomicGpu)
+    {
+        // Update atom mapping on NS steps (DD redistribution or first call)
+        if (stepWork.doNeighborSearch)
+        {
+            const int* globalAtomIndices =
+                    haveDDAtomOrdering(*cr) ? cr->dd->globalAtomIndices.data() : nullptr;
+            const int numTotalLocal =
+                    haveDDAtomOrdering(*cr)
+                            ? static_cast<int>(cr->dd->globalAtomIndices.size())
+                            : mdatoms->homenr;
+            fr->metatomicGpu->updateAtomMapping(mdatoms->homenr, numTotalLocal, globalAtomIndices);
+        }
+
+        const GpuPairlist* gpuPl      = gpuGetPairlist(nbv->gpuNbv(), InteractionLocality::Local);
+        DeviceBuffer<int>  d_atomIdx  = gpuGetAtomIndex(nbv->gpuNbv());
+        NBAtomDataGpu*     nbAtomData = gpuGetNBAtomData(nbv->gpuNbv());
+        fr->metatomicGpu->calculateForces(stateGpu->getCoordinates(),
+                                           mdatoms->homenr,
+                                           box,
+                                           step,
+                                           gpuPl,
+                                           d_atomIdx,
+                                           nbAtomData,
+                                           stepWork.doNeighborSearch);
     }
 
     if (stepWork.haveGpuPmeOnThisRank)
@@ -2288,6 +2329,12 @@ void do_force(FILE*                         fplog,
                                    stepWork.useGpuPmeFReduction,
                                    wcycle);
         }
+    }
+
+    // GPU metatomic: apply energy, virial, and (DD) forces now that ForceWithVirial exists
+    if (simulationWork.useGpuMetatomic && fr->metatomicGpu)
+    {
+        fr->metatomicGpu->applyOutputs(enerd, &forceOutMtsLevel0.forceWithVirial());
     }
 
     if (domainWork.haveSpecialForces)

--- a/src/gromacs/mdrun/mdmodules.cpp
+++ b/src/gromacs/mdrun/mdmodules.cpp
@@ -174,7 +174,8 @@ void MDModules::initMdpTransform(IKeyValueTreeTransformRules* rules)
                                          QMMMModuleInfo::sc_name,
                                          ColvarsModuleInfo::sc_name,
                                          NNPotModuleInfo::sc_name,
-                                         MetatomicModuleInfo::sc_name })
+                                         MetatomicModuleInfo::sc_name,
+                                         MetatomicGpuModuleInfo::sc_name })
     {
         IMDModule*          module            = impl_->modules_.at(std::string(moduleName)).get();
         IMdpOptionProvider* mdpOptionProvider = module->mdpOptionProvider();
@@ -199,7 +200,8 @@ void MDModules::buildMdpOutput(KeyValueTreeObjectBuilder* builder)
                                          QMMMModuleInfo::sc_name,
                                          ColvarsModuleInfo::sc_name,
                                          NNPotModuleInfo::sc_name,
-                                         MetatomicModuleInfo::sc_name })
+                                         MetatomicModuleInfo::sc_name,
+                                         MetatomicGpuModuleInfo::sc_name })
     {
         IMDModule*                module = impl_->modules_.at(std::string(moduleName)).get();
         const IMdpOptionProvider* mdpOptionProvider = module->mdpOptionProvider();

--- a/src/gromacs/mdrun/mdmodules.cpp
+++ b/src/gromacs/mdrun/mdmodules.cpp
@@ -44,6 +44,7 @@
 #include "gromacs/applied_forces/colvars/colvarsMDModule.h"
 #include "gromacs/applied_forces/densityfitting/densityfitting.h"
 #include "gromacs/applied_forces/electricfield.h"
+#include "gromacs/applied_forces/metatomic/metatomic_gpu_mdmodule.h"
 #include "gromacs/applied_forces/metatomic/metatomic_mdmodule.h"
 #include "gromacs/applied_forces/nnpot/nnpot.h"
 #include "gromacs/applied_forces/plumed/plumedMDModule.h"
@@ -88,6 +89,7 @@ public:
         modules_[std::string(NNPotModuleInfo::sc_name)]     = NNPotModuleInfo::create();
         modules_[std::string(FmmModuleInfo::sc_name)]       = FmmModuleInfo::create();
         modules_[std::string(MetatomicModuleInfo::sc_name)] = MetatomicModuleInfo::create();
+        modules_[std::string(MetatomicGpuModuleInfo::sc_name)] = MetatomicGpuModuleInfo::create();
     }
 
     void makeModuleOptions(Options* options) const
@@ -105,7 +107,8 @@ public:
                                              QMMMModuleInfo::sc_name,
                                              ColvarsModuleInfo::sc_name,
                                              NNPotModuleInfo::sc_name,
-                                             MetatomicModuleInfo::sc_name })
+                                             MetatomicModuleInfo::sc_name,
+                                             MetatomicGpuModuleInfo::sc_name })
         {
             IMDModule*          module            = modules_.at(std::string(moduleName)).get();
             IMdpOptionProvider* mdpOptionProvider = module->mdpOptionProvider();

--- a/src/gromacs/mdrun/runner.cpp
+++ b/src/gromacs/mdrun/runner.cpp
@@ -60,6 +60,8 @@
 #include <variant>
 #include <vector>
 
+#include "gromacs/applied_forces/metatomic/metatomic_gpu_forceprovider.h"
+#include "gromacs/applied_forces/metatomic/metatomic_options.h"
 #include "gromacs/commandline/filenm.h"
 #include "gromacs/domdec/builder.h"
 #include "gromacs/domdec/domdec.h"
@@ -1632,6 +1634,33 @@ int Mdrunner::mdrunner()
             canUseDirectGpuComm,
             useGpuPmeDecomposition);
 
+    // GPU-resident metatomic: check MDP options (KVT) and env var override
+    {
+        bool gpuMetatomicFromMdp = false;
+        if (inputrec->params->keyExists("applied-forces"))
+        {
+            const auto& afSection = (*inputrec->params)["applied-forces"].asObject();
+            if (afSection.keyExists("metatomic-gpu"))
+            {
+                const auto& mgSection = afSection["metatomic-gpu"].asObject();
+                if (mgSection.keyExists("active"))
+                {
+                    gpuMetatomicFromMdp = mgSection["active"].cast<bool>();
+                }
+            }
+        }
+        const bool gpuMetatomicFromEnv = (getenv("GMX_METATOMIC_GPU") != nullptr);
+        if ((gpuMetatomicFromMdp || gpuMetatomicFromEnv) && deviceInfo != nullptr)
+        {
+            runScheduleWork.simulationWork.useGpuMetatomic = true;
+            GMX_LOG(mdlog.info)
+                    .asParagraph()
+                    .appendTextFormatted(
+                            "GPU-resident metatomic force evaluation enabled (%s).",
+                            gpuMetatomicFromMdp ? "MDP option" : "GMX_METATOMIC_GPU env var");
+        }
+    }
+
     if (GMX_LIB_MPI && deviceInfo
         && (runScheduleWork.simulationWork.useGpuDirectCommunication
             || runScheduleWork.simulationWork.useGpuPmeDecomposition
@@ -1947,6 +1976,103 @@ int Mdrunner::mdrunner()
                                                       deviceStreamManager->context(),
                                                       deviceStreamManager->bondedStream(),
                                                       wcycle.get());
+        }
+        if (runScheduleWork.simulationWork.useGpuMetatomic)
+        {
+            GMX_RELEASE_ASSERT(deviceStreamManager != nullptr,
+                               "GPU device stream manager should be valid in order to use GPU "
+                               "metatomic force provider.");
+            MetatomicParameters metatomicGpuParams;
+            metatomicGpuParams.active = true;
+            metatomicGpuParams.device = "cuda";
+            metatomicGpuParams.nlMode = "full";
+
+            // Read model path: env var overrides MDP/KVT
+            const char* modelPathEnv = getenv("GMX_METATOMIC_MODEL_PATH");
+            if (modelPathEnv != nullptr)
+            {
+                metatomicGpuParams.modelPath_ = modelPathEnv;
+            }
+            else if (inputrec->params->keyExists("applied-forces"))
+            {
+                const auto& afSection = (*inputrec->params)["applied-forces"].asObject();
+                // Try GPU-specific model path first, then fall back to CPU metatomic path
+                for (const std::string& sectionName : { "metatomic-gpu", "metatomic" })
+                {
+                    if (afSection.keyExists(sectionName))
+                    {
+                        const auto& section = afSection[sectionName].asObject();
+                        if (section.keyExists("model-path"))
+                        {
+                            metatomicGpuParams.modelPath_ = section["model-path"].cast<std::string>();
+                            break;
+                        }
+                    }
+                }
+            }
+            if (metatomicGpuParams.modelPath_.empty())
+            {
+                GMX_THROW(InconsistentInputError(
+                        "GPU metatomic is active but no model path found. "
+                        "Set metatomic-gpu-model-path in MDP or GMX_METATOMIC_MODEL_PATH env var."));
+            }
+
+            // Extensions directory: env var overrides KVT
+            const char* extDirEnv = getenv("GMX_METATOMIC_EXTENSIONS_DIR");
+            if (extDirEnv != nullptr)
+            {
+                metatomicGpuParams.extensionsDirectory = extDirEnv;
+            }
+            else if (inputrec->params->keyExists("applied-forces"))
+            {
+                const auto& afSection = (*inputrec->params)["applied-forces"].asObject();
+                if (afSection.keyExists("metatomic-gpu"))
+                {
+                    const auto& mgSection = afSection["metatomic-gpu"].asObject();
+                    if (mgSection.keyExists("extensions-directory"))
+                    {
+                        metatomicGpuParams.extensionsDirectory =
+                                mgSection["extensions-directory"].cast<std::string>();
+                    }
+                }
+            }
+
+            // Variant: from KVT
+            if (inputrec->params->keyExists("applied-forces"))
+            {
+                const auto& afSection = (*inputrec->params)["applied-forces"].asObject();
+                if (afSection.keyExists("metatomic-gpu"))
+                {
+                    const auto& mgSection = afSection["metatomic-gpu"].asObject();
+                    if (mgSection.keyExists("variant"))
+                    {
+                        metatomicGpuParams.variant = mgSection["variant"].cast<std::string>();
+                    }
+                }
+            }
+
+            // Extract global atomic numbers from topology for GPU path
+            std::vector<int> globalAtomicNumbers;
+            globalAtomicNumbers.reserve(mtop.natoms);
+            for (const auto& molblock : mtop.molblock)
+            {
+                const auto& atoms = mtop.moltype[molblock.type].atoms;
+                for (int m = 0; m < molblock.nmol; m++)
+                {
+                    for (int a = 0; a < atoms.nr; a++)
+                    {
+                        globalAtomicNumbers.push_back(atoms.atom[a].atomnumber);
+                    }
+                }
+            }
+
+            fr->metatomicGpu = std::make_unique<MetatomicGpuForceProvider>(
+                    metatomicGpuParams,
+                    mdlog,
+                    deviceStreamManager->context(),
+                    deviceStreamManager->stream(DeviceStreamType::NonBondedLocal),
+                    cr->commMySim,
+                    std::move(globalAtomicNumbers));
         }
         fr->longRangeNonbondeds = std::make_unique<CpuPpLongRangeNonbondeds>(fr->n_tpi,
                                                                              fr->ic->coulomb.ewaldCoeff,

--- a/src/gromacs/mdrun/runner.cpp
+++ b/src/gromacs/mdrun/runner.cpp
@@ -1985,7 +1985,6 @@ int Mdrunner::mdrunner()
             MetatomicParameters metatomicGpuParams;
             metatomicGpuParams.active = true;
             metatomicGpuParams.device = "cuda";
-            metatomicGpuParams.nlMode = "full";
 
             // Read model path: env var overrides MDP/KVT
             const char* modelPathEnv = getenv("GMX_METATOMIC_MODEL_PATH");

--- a/src/gromacs/mdrun/runner.cpp
+++ b/src/gromacs/mdrun/runner.cpp
@@ -1996,7 +1996,7 @@ int Mdrunner::mdrunner()
             {
                 const auto& afSection = (*inputrec->params)["applied-forces"].asObject();
                 // Try GPU-specific model path first, then fall back to CPU metatomic path
-                for (const std::string& sectionName : { "metatomic-gpu", "metatomic" })
+                for (const auto& sectionName : { std::string("metatomic-gpu"), std::string("metatomic") })
                 {
                     if (afSection.keyExists(sectionName))
                     {

--- a/src/gromacs/mdtypes/forcerec.h
+++ b/src/gromacs/mdtypes/forcerec.h
@@ -70,6 +70,7 @@ class ForceProviders;
 class MdGpuGraph;
 class StatePropagatorDataGpu;
 class PmePpCommGpu;
+class MetatomicGpuForceProvider;
 class WholeMoleculeTransform;
 } // namespace gmx
 
@@ -274,6 +275,9 @@ struct t_forcerec
 
     /* For PME-PP GPU communication */
     std::unique_ptr<gmx::PmePpCommGpu> pmePpCommGpu;
+
+    /* GPU-resident metatomic force provider (pure-ML, bypasses IForceProvider) */
+    std::unique_ptr<gmx::MetatomicGpuForceProvider> metatomicGpu;
 
     /* For GPU force reduction (on both local and non-local atoms) */
     gmx::EnumerationArray<gmx::AtomLocality, std::unique_ptr<gmx::GpuForceReduction>> gpuForceReduction;

--- a/src/gromacs/mdtypes/simulation_workload.h
+++ b/src/gromacs/mdtypes/simulation_workload.h
@@ -221,6 +221,8 @@ public:
     bool useMdGpuGraph = false;
     //! Whether to use NVSHMEM enabled GPU initiated communication.
     bool useNvshmem = false;
+    //! Whether GPU-resident metatomic force evaluation is active.
+    bool useGpuMetatomic = false;
 
     //! Whether PME GPU is active on this PP rank (note that currently only PP ranks use SimulationWorkload)
 #if !defined(_MSC_VER) // MSVC does not support __attribute__

--- a/src/gromacs/nbnxm/gpu_data_mgmt.h
+++ b/src/gromacs/nbnxm/gpu_data_mgmt.h
@@ -157,6 +157,17 @@ NBAtomDataGpu* gpuGetNBAtomData(NbnxmGpu gmx_unused* nb) GPU_FUNC_TERM_WITH_RETU
 GPU_FUNC_QUALIFIER
 DeviceBuffer<RVec> gpu_get_f(NbnxmGpu gmx_unused* nb) GPU_FUNC_TERM_WITH_RETURN(DeviceBuffer<RVec>{});
 
+/** Returns pointer to the GPU pairlist for the given locality. */
+GPU_FUNC_QUALIFIER
+const GpuPairlist* gpuGetPairlist(const NbnxmGpu gmx_unused* nb,
+                                  InteractionLocality gmx_unused iloc)
+        GPU_FUNC_TERM_WITH_RETURN(nullptr);
+
+/** Returns DeviceBuffer of the nbnxm-to-natural atom index mapping. */
+GPU_FUNC_QUALIFIER
+DeviceBuffer<int> gpuGetAtomIndex(const NbnxmGpu gmx_unused* nb)
+        GPU_FUNC_TERM_WITH_RETURN(DeviceBuffer<int>{});
+
 /*! \brief Calculates working memory required for exclusive sum, used in neighbour list sorting on GPU.
  *
  * This is only used for CUDA/HIP, where the actual size is calculate based on the list.

--- a/src/gromacs/nbnxm/nbnxm_gpu_data_mgmt.cpp
+++ b/src/gromacs/nbnxm/nbnxm_gpu_data_mgmt.cpp
@@ -1764,4 +1764,16 @@ DeviceBuffer<RVec> gpu_get_f(NbnxmGpu* nb)
     return nb->atdat->f;
 }
 
+const GpuPairlist* gpuGetPairlist(const NbnxmGpu* nb, InteractionLocality iloc)
+{
+    GMX_ASSERT(nb != nullptr, "nb pointer must be valid");
+    return nb->plist[iloc].get();
+}
+
+DeviceBuffer<int> gpuGetAtomIndex(const NbnxmGpu* nb)
+{
+    GMX_ASSERT(nb != nullptr, "nb pointer must be valid");
+    return nb->atomIndices;
+}
+
 } // namespace gmx


### PR DESCRIPTION
## Summary

- Pure-ML GPU path (`MetatomicGpuForceProvider`) bypassing `IForceProvider` for zero-copy coordinate wrapping, GPU NL construction from nbnxm `GpuPairlist`, and GPU-resident model evaluation
- PME GPU integration pattern: `DeviceBuffer<RVec>` + `GpuEventSynchronizer` registered with `GpuForceReduction`
- CUDA kernel converts nbnxm `GpuPairlist` to metatensor NL format on device; no D2H copies in single-rank hot path
- DD supported: GPU model eval + CPU sparse MPI force exchange (same pattern as CPU `MetatomicForceProvider`)
- New nbnxm accessors `gpuGetPairlist()` and `gpuGetAtomIndex()` for GPU pairlist access
- Activation via `metatomic-gpu` MDP section or `GMX_METATOMIC_GPU` env var; CUDA build required (stub for CPU-only)

### Single-rank GPU-resident only; no multi-GPU

The zero-copy force output via `GpuForceReduction` is gated on `!hasDomainDecomposition()`. With DD, forces go to CPU for sparse MPI exchange through `distributeNonHomeForces()`. No multi-GPU support exists: LAMMPS Kokkos handles this via `MPI_Comm_split_type` round-robin GPU assignment, but the metatomic GPU path just uses whatever device GROMACS assigns through `DeviceStreamManager`. Multi-rank multi-GPU is untested.

### Not upstream-ready

The GPU force provider bypasses `IForceProvider` and wires directly into `do_force()` in `sim_util.cpp` (coordinate sync, atom mapping, NL build, model evaluation, output application) and `runner.cpp` (provider construction, model path resolution from KVT, topology iteration). It also adds a `metatomicGpu` member to `t_forcerec`, a `useGpuMetatomic` flag to `SimulationWork`, and nbnxm accessors that expose internal GPU data structures.

Upstreaming would require a proper GPU force provider interface (analogous to PME GPU integration) rather than the current direct wiring. Either `IForceProvider` needs GPU buffer support, or a separate `IGpuForceProvider` interface with `DeviceBuffer` input/output.

### Phase 1 audit (latest commit)

- Device validation: `GMX_RELEASE_ASSERT` that `DeviceContext` matches `cudaGetDevice()`
- Coordinate lifetime: debug-mode checksum of `d_x` before model eval, verified unchanged after `backward()` (fires with `GMX_METATOMIC_DEBUG=1`)
- Interaction range: GPU module registers `interaction_range + max_nl_cutoff` (prerequisite for Newton-mode DD)
- Stub fix: CPU builds failed to link because the stub was missing the `xReadyOnDevice` parameter
- Parity test: `TestGPUCPUParity` asserts GPU/CPU step-0 energy within 1 kJ/mol

## Test plan

- [x] CPU build (`metatomic-cpu` env) compiles with stub
- [x] Existing CPU metatomic tests pass
- [x] CI benchmark workflow fixed (stub signature mismatch was the CPU link failure)
- [ ] CUDA build (`metatomic-cuda` env) on remote workstation
- [ ] Single-rank GPU energy matches CPU reference (`TestGPUCPUParity`)
- [ ] DD GPU energy matches serial GPU reference
- [ ] `nsys profile` confirms no GPU-CPU copies in single-rank hot path